### PR TITLE
WIP on projectivity branch

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -111,7 +111,6 @@ theories/Spaces/Card.v
 theories/Spaces/Circle.v
 theories/Spaces/TwoSphere.v
 theories/Spaces/Spheres.v
-theories/Spaces/Projective.v
 
 theories/Spaces/Int.v
 theories/Spaces/Int/Core.v
@@ -244,6 +243,7 @@ theories/HFiber.v
 theories/HProp.v
 theories/Extensions.v
 theories/HSet.v
+theories/Projective.v
 theories/TruncType.v
 theories/DProp.v
 theories/EquivGroupoids.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -111,6 +111,7 @@ theories/Spaces/Card.v
 theories/Spaces/Circle.v
 theories/Spaces/TwoSphere.v
 theories/Spaces/Spheres.v
+theories/Spaces/Projective.v
 
 theories/Spaces/Int.v
 theories/Spaces/Int/Core.v

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -1619,6 +1619,7 @@ End Book_7_1.
 
 (* ================================================== ex:acnm-surjset *)
 (** Exercise 7.9 *)
+(* Solved for AC_(oo,-1) by projective_cover_AC in Spaces/Projective.v *)
 
 
 

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -400,6 +400,14 @@ Definition equiv_iff_hprop `{IsHProp A} `{IsHProp B}
   : (A -> B) -> (B -> A) -> (A <~> B)
   := fun f g => equiv_iff_hprop_uncurried (f, g).
 
+Corollary equiv_contr_hprop (A : Type) `{Funext} `{IsHProp A}
+  : Contr A <~> A.
+Proof.
+  rapply equiv_iff_hprop.
+  - apply center.
+  - rapply contr_inhabited_hprop.
+Defined.
+
 (** Truncatedness is an hprop. *)
 Global Instance ishprop_istrunc `{Funext} (n : trunc_index) (A : Type)
   : IsHProp (IsTrunc n A) | 0.

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -121,6 +121,13 @@ Proof.
   exact (ap pr1 q).
 Defined.
 
+Definition isinj_section {A B : Type} {s : A -> B} {r : B -> A}
+      (H : r o s == idmap) : isinj s.
+Proof.
+  intros a a' alpha.
+  exact ((H a)^ @ ap r alpha @ H a').
+Defined.
+
 Lemma isembedding_isinj_hset {A B : Type} `{IsHSet B} (m : A -> B)
 : isinj m -> IsEmbedding m.
 Proof.

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -12,6 +12,7 @@ Require Export HoTT.Truncations.
 
 Require Export HoTT.HFiber.
 Require Export HoTT.HProp.
+Require Export HoTT.Projective.
 Require Export HoTT.HSet.
 Require Export HoTT.EquivGroupoids.
 

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1346,6 +1346,7 @@ Section ModalMaps.
     refine (inO_equiv_inO (B a) (hfiber_fibration a B)).
   Defined.
 
+
   (** A slightly specialized result: if [Empty] is modal, then a map with decidable hprop fibers (such as [inl] or [inr]) is modal. *)
   Global Instance mapinO_hfiber_decidable_hprop {A B : Type} (f : A -> B)
          `{In O Empty}
@@ -1364,6 +1365,16 @@ Section ModalMaps.
   : IsHProp (MapIn O f).
   Proof.
     apply trunc_forall.
+  Defined.
+
+  Lemma equiv_forall_inO_mapinO_pr1 `{Funext} {A : Type} {B : A -> Type}
+    : (forall a, In O (B a)) <~> MapIn O (@pr1 A B).
+  Proof.
+    apply equiv_iff_hprop.
+    - intro f; apply mapinO_pr1.
+    - apply functor_forall_id; intros a inO.
+      srapply inO_equiv_inO'.
+      exact (hfiber_fibration a B)^-1%equiv.
   Defined.
 
   (** Any map between modal types is modal. *)
@@ -1497,6 +1508,17 @@ Section ConnectedMaps.
   : IsHProp (IsConnMap O f).
   Proof.
     apply trunc_forall.
+  Defined.
+
+  (** *** TODO: Avoid univalence, if possible. *)
+  Lemma equiv_forall_isconnmap_pr1 `{Univalence} {A : Type} {B : A -> Type}
+    : (forall a, Contr (O (B a))) <~> IsConnMap O (@pr1 A B).
+  Proof.
+    apply equiv_functor_forall_id; intro a. unfold IsConnected.
+    apply equiv_path.
+    apply (ap (Contr o O)).
+    apply (equiv_equiv_path _ _)^-1%equiv.
+    exact (hfiber_fibration a B).
   Defined.
 
   (** Connected maps are orthogonal to modal maps (i.e. familes of modal types). *)

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -105,17 +105,16 @@ Section Subuniverse.
   : MapIn O (@pr1 A B).
   Proof.
     intros a.
-    refine (inO_equiv_inO (B a) (hfiber_fibration a B)).
+    exact (inO_equiv_inO (B a) (hfiber_fibration a B)).
   Defined.
 
   Lemma equiv_forall_inO_fiber_pr1 `{Funext} {A : Type} (B : A -> Type)
     : (forall a, In O (B a)) <~> MapIn O (@pr1 A B).
   Proof.
-    unfold MapIn; apply equiv_iff_hprop.
-    - intro f; apply mapinO_pr1.
-    - apply functor_forall_id; intros a inO.
-      srapply inO_equiv_inO'.
-      exact (hfiber_fibration a B)^-1%equiv.
+    unfold MapIn.
+    apply equiv_functor_forall_id; intro a.
+    apply inO_equiv_inO''.
+    exact (hfiber_fibration a B).
   Defined.
 
   (** Being a local map is an hprop *)
@@ -1268,11 +1267,9 @@ Section ConnectedTypes.
     := isconnected_equiv A f.
 
   (** The O-connected types form a subuniverse. *)
-  Theorem subuniverse_connected : Subuniverse.
+  Definition Conn : Subuniverse.
   Proof.
-    econstructor. Unshelve.
-    3: exact (IsConnected O).
-    1: intros F T; exact _.
+    rapply (Build_Subuniverse (IsConnected O)).
     simpl; intros T U isconnT f isequivf.
     exact (isconnected_equiv T f isconnT).
   Defined.
@@ -1479,14 +1476,6 @@ Class IsConnMap (O : ReflectiveSubuniverse@{i})
      : forall b:B, IsConnected@{i} O (hfiber@{i i} f b).
 
 Global Existing Instance isconnected_hfiber_conn_map.
-
-Proposition equiv_forall_isconnmap_pr1 `{Funext} (O : ReflectiveSubuniverse) {A : Type} (B : A -> Type)
-  : (forall a, IsConnected O (B a)) <~> IsConnMap O (@pr1 A B).
-Proof.
-  apply equiv_functor_forall_id; intro a.
-  pose (S := subuniverse_connected O).
-  apply (inO_equiv_inO'' (subuniverse_connected O) (hfiber_fibration a B)).
-Defined.
 
 Section ConnectedMaps.
   Context `{Univalence} `{Funext}.

--- a/theories/Modalities/Separated.v
+++ b/theories/Modalities/Separated.v
@@ -98,6 +98,13 @@ Proof.
   refine (inO_equiv_inO' _ (equiv_ap_isembedding i x y)^-1).
 Defined.
 
+(* As a special case, if X embeds into an n-type for n >= -1 then X is an n-type. Note that this doesn't hold for n = -2. *)
+Corollary istrunc_embedding_trunc `{Funext} {X Y : Type} {n : trunc_index} `{IsTrunc n.+1 Y}
+      (i : X -> Y) `{IsEmbedding i} : IsTrunc n.+1 X.
+Proof.
+  exact (@in_SepO_embedding (Tr n) _ _ i IsEmbedding0 H0).
+Defined.
+
 Global Instance in_SepO_hprop (O : ReflectiveSubuniverse)
        {A : Type} `{IsHProp A}
   : In (Sep O) A.
@@ -105,6 +112,7 @@ Proof.
   srapply (in_SepO_embedding O (const tt)).
   intros x y; exact _.
 Defined.
+
 
 (** Remark 2.16(4) of CORS *)
 Definition sigma_closed_SepO (O : Modality) {A : Type} (B : A -> Type)

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -1,23 +1,23 @@
-Require Import Basics Types HProp HSet HFiber Truncations.
+Require Import Basics Types HProp HFiber HSet.
+Require Import Truncations.
 Require Import Modalities.Descent Modalities.Separated.
-Require Import Limits.Pullback Spaces.Finite.
+Require Import Limits.Pullback.
 
 
 (** * Projective types *)
 
-Definition IsProjective (X : Type)
+Definition IsProjective (X : Type) : Type
   := forall A B : Type, forall f : X -> B, forall p : A -> B,
         IsSurjection p -> merely (exists s : X -> A, p o s == f).
 
 (** A type X is projective if and only if surjections into X merely split. *)
-Proposition equiv_isprojective_surjections_split `{Funext} (X : Type)
-  : IsProjective X <~>
-    (forall (Y:Type), forall (p : Y -> X),
+Proposition iff_isprojective_surjections_split (X : Type)
+  : IsProjective X <->
+    (forall (Y : Type), forall (p : Y -> X),
           IsSurjection p -> merely (exists s : X -> Y, p o s == idmap)).
 Proof.
-  srapply equiv_iff_hprop.
-  - intro isprojX. unfold IsProjective in isprojX.
-    intros Y p S.
+  econstructor.
+  - intros isprojX Y p S; unfold IsProjective in isprojX.
     exact (isprojX Y X idmap p S).
   - intro splits. unfold IsProjective.
     intros A B f p S.
@@ -31,38 +31,28 @@ Proof.
     apply E.
 Defined.
 
+Corollary equiv_isprojective_surjections_split `{Funext} (X : Type)
+  : IsProjective X <~>
+    (forall (Y : Type), forall (p : Y -> X),
+          IsSurjection p -> merely (exists s : X -> Y, p o s == idmap)).
+Proof.
+  exact (equiv_iff_hprop_uncurried (iff_isprojective_surjections_split X)).
+Defined.
+
+
 (** ** Projectivity and choice *)
 
-Definition choice (X : Type) := forall P : X -> Type,
-      (forall x, merely (P x)) -> merely (forall x, P x).
+Definition Choice (X : Type) : Type := forall P : X -> Type,
+    (forall x, merely (P x)) -> merely (forall x, P x).
 
-(* The following two lemmas make the proof of equiv_isprojective_choice below easier to follow. *)
-Lemma equiv_contr_hprop `{Funext} (A : Type) `{IsHProp A}
-  : Contr A <~> A.
-Proof.
-  rapply equiv_iff_hprop.
-  - apply center.
-  - rapply contr_inhabited_hprop.
-Defined.
-
-Lemma equiv_isconnmap_merely `{Funext} {X : Type} (P : X -> Type)
-  : IsConnMap (Tr (-1)) (pr1 : {x : X & P x} -> X) <~> forall x : X, merely (P x).
-Proof.
-  apply equiv_functor_forall_id; intro x.
-  unfold IsConnected.
-  refine (_ oE equiv_contr_hprop _).
-  apply Trunc_functor_equiv.
-  symmetry; apply hfiber_fibration.
-Defined.
-
-Proposition equiv_isprojective_choice `{Funext} (X : Type)
-  : IsProjective X <~> choice X.
+Proposition equiv_isprojective_choice `{Univalence} (X : Type)
+  : IsProjective X <~> Choice X.
 Proof.
   refine (_ oE equiv_isprojective_surjections_split X).
   srapply equiv_iff_hprop.
   - intros splits P S.
     specialize splits with {x : X & P x} pr1.
-    pose proof (splits ((equiv_isconnmap_merely P)^-1%equiv S)) as M.
+    pose proof (splits ((equiv_merely_issurjection P) S)) as M.
     clear S splits.
     strip_truncations; apply tr.
     destruct M as [s p].
@@ -77,14 +67,7 @@ Proof.
     exact (fun x => (M x).2).
 Defined.
 
-(** Finite sets (as in Spaces/Finite.v) are projective. *)
-Theorem isprojective_fin_n `{Funext} (n : nat) : IsProjective (Fin n).
-Proof.
-  apply (equiv_isprojective_choice (Fin n))^-1.
-  rapply finite_choice.
-Defined.
-
-Proposition isprojective_unit `{Funext} : IsProjective Unit.
+Proposition isprojective_unit `{Univalence} : IsProjective Unit.
 Proof.
   apply (equiv_isprojective_choice Unit)^-1.
   intros P S.
@@ -94,12 +77,12 @@ Proof.
   exact S.
 Defined.
 
-
+(** *** Ideally I think this section should live in HSet.v, but I can't get the imports to work. *)
 Section AC_oo_neg1.
   (** ** Projectivity and AC_(oo,-1) (defined in HoTT book, Exercise 7.8) *)
   (* TODO: Generalize to n, m. *)
 
-  Context {AC : forall X : hSet, choice X}.
+  Context {AC : forall X : hSet, Choice X}.
 
   (** (Exercise 7.9) Assuming AC_(oo,-1) every type merely has a projective cover. *)
   Proposition projective_cover_AC `{Univalence} (A : Type)

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -45,7 +45,7 @@ Defined.
 Definition Choice (X : Type) : Type := forall P : X -> Type,
     (forall x, merely (P x)) -> merely (forall x, P x).
 
-Proposition equiv_isprojective_choice `{Univalence} (X : Type)
+Proposition equiv_isprojective_choice `{Funext} (X : Type)
   : IsProjective X <~> Choice X.
 Proof.
   refine (_ oE equiv_isprojective_surjections_split X).
@@ -77,7 +77,6 @@ Proof.
   exact S.
 Defined.
 
-(** *** Ideally I think this section should live in HSet.v, but I can't get the imports to work. *)
 Section AC_oo_neg1.
   (** ** Projectivity and AC_(oo,-1) (defined in HoTT book, Exercise 7.8) *)
   (* TODO: Generalize to n, m. *)

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -16,7 +16,7 @@ Proposition iff_isprojective_surjections_split (X : Type)
     (forall (Y : Type), forall (p : Y -> X),
           IsSurjection p -> merely (exists s : X -> Y, p o s == idmap)).
 Proof.
-  econstructor.
+  split.
   - intros isprojX Y p S; unfold IsProjective in isprojX.
     exact (isprojX Y X idmap p S).
   - intro splits. unfold IsProjective.

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -589,8 +589,7 @@ Proof.
       exact (tr (sum_ind P IH (Unit_ind e))).
 Defined.
 
-(** *TODO Avoid univalence. *)
-Corollary isprojective_fin_n `{Univalence} (n : nat) : IsProjective (Fin n).
+Corollary isprojective_fin_n `{Funext} (n : nat) : IsProjective (Fin n).
 Proof.
   apply (equiv_isprojective_choice (Fin n))^-1.
   rapply finite_choice.

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -10,6 +10,7 @@ Require Import Factorization.
 Require Import Equiv.PathSplit.
 Require Import Truncations.
 Require Import Colimits.Quotient.
+Require Import Projective.
 
 Local Open Scope path_scope.
 Local Open Scope nat_scope.
@@ -566,10 +567,10 @@ Proof.
   - refine (transport (P (Fin n.+1)) (path_ishprop _ _) (fs _ _ IH)).
 Defined.
 
-(** ** The finite axiom of choice *)
+(** ** The finite axiom of choice, and projectivity *)
 
 Definition finite_choice {X} `{Finite X} (P : X -> Type)
-: (forall x, merely (P x)) -> merely (forall x, P x).
+  : (forall x, merely (P x)) -> merely (forall x, P x).
 Proof.
   intros f.
   assert (e := merely_equiv_fin X).
@@ -586,6 +587,13 @@ Proof.
       assert (e := f (inr tt)).
       strip_truncations.
       exact (tr (sum_ind P IH (Unit_ind e))).
+Defined.
+
+(** *TODO Avoid univalence. *)
+Corollary isprojective_fin_n `{Univalence} (n : nat) : IsProjective (Fin n).
+Proof.
+  apply (equiv_isprojective_choice (Fin n))^-1.
+  rapply finite_choice.
 Defined.
 
 (** ** Constructions on finite sets *)

--- a/theories/Spaces/Projective.v
+++ b/theories/Spaces/Projective.v
@@ -1,0 +1,142 @@
+Require Import Basics Types HProp HSet HFiber Truncations.
+Require Import Modalities.Descent Modalities.Separated.
+Require Import Limits.Pullback Spaces.Finite.
+
+
+(** * Projective types *)
+
+Definition IsProjective (X : Type)
+  := forall A B : Type, forall f : X -> B, forall p : A -> B,
+        IsSurjection p -> merely (exists s : X -> A, p o s == f).
+
+(** A type X is projective if and only if surjections into X merely split. *)
+Proposition equiv_isprojective_surjections_split `{Funext} (X : Type)
+  : IsProjective X <~>
+    (forall (Y:Type), forall (p : Y -> X),
+          IsSurjection p -> merely (exists s : X -> Y, p o s == idmap)).
+Proof.
+  srapply equiv_iff_hprop.
+  - intro isprojX. unfold IsProjective in isprojX.
+    intros Y p S.
+    exact (isprojX Y X idmap p S).
+  - intro splits. unfold IsProjective.
+    intros A B f p S.
+    pose proof (splits (Pullback p f) pullback_pr2 _) as s'.
+    strip_truncations.
+    destruct s' as [s E].
+    refine (tr (pullback_pr1 o s; _)).
+    intro x.
+    refine (pullback_commsq p f (s x) @ _).
+    apply (ap f).
+    apply E.
+Defined.
+
+(** ** Projectivity and choice *)
+
+Definition choice (X : Type) := forall P : X -> Type,
+      (forall x, merely (P x)) -> merely (forall x, P x).
+
+(* The following two lemmas make the proof of equiv_isprojective_choice below easier to follow. *)
+Lemma equiv_contr_hprop `{Funext} (A : Type) `{IsHProp A}
+  : Contr A <~> A.
+Proof.
+  rapply equiv_iff_hprop.
+  - apply center.
+  - rapply contr_inhabited_hprop.
+Defined.
+
+Lemma equiv_isconnmap_merely `{Funext} {X : Type} (P : X -> Type)
+  : IsConnMap (Tr (-1)) (pr1 : {x : X & P x} -> X) <~> forall x : X, merely (P x).
+Proof.
+  apply equiv_functor_forall_id; intro x.
+  unfold IsConnected.
+  refine (_ oE equiv_contr_hprop _).
+  apply Trunc_functor_equiv.
+  symmetry; apply hfiber_fibration.
+Defined.
+
+Proposition equiv_isprojective_choice `{Funext} (X : Type)
+  : IsProjective X <~> choice X.
+Proof.
+  refine (_ oE equiv_isprojective_surjections_split X).
+  srapply equiv_iff_hprop.
+  - intros splits P S.
+    specialize splits with {x : X & P x} pr1.
+    pose proof (splits ((equiv_isconnmap_merely P)^-1%equiv S)) as M.
+    clear S splits.
+    strip_truncations; apply tr.
+    destruct M as [s p].
+    intro x.
+    exact (transport _ (p x) (s x).2).
+  - intros choiceX Y p S.
+    unfold IsConnMap, IsConnected in S.
+    pose proof (fun b => (@center _ (S b))) as S'; clear S.
+    pose proof (choiceX (hfiber p) S') as M; clear S'.
+    strip_truncations; apply tr.
+    exists (fun x => (M x).1).
+    exact (fun x => (M x).2).
+Defined.
+
+(** Finite sets (as in Spaces/Finite.v) are projective. *)
+Theorem isprojective_fin_n `{Funext} (n : nat) : IsProjective (Fin n).
+Proof.
+  apply (equiv_isprojective_choice (Fin n))^-1.
+  rapply finite_choice.
+Defined.
+
+Proposition isprojective_unit `{Funext} : IsProjective Unit.
+Proof.
+  apply (equiv_isprojective_choice Unit)^-1.
+  intros P S.
+  specialize S with tt.
+  strip_truncations; apply tr.
+  apply Unit_ind.
+  exact S.
+Defined.
+
+
+Section AC_oo_neg1.
+  (** ** Projectivity and AC_(oo,-1) (defined in HoTT book, Exercise 7.8) *)
+  (* TODO: Generalize to n, m. *)
+
+  Context {AC : forall X : hSet, choice X}.
+
+  (** (Exercise 7.9) Assuming AC_(oo,-1) every type merely has a projective cover. *)
+  Proposition projective_cover_AC `{Univalence} (A : Type)
+    : merely (exists X:hSet, exists p : X -> A, IsSurjection p).
+  Proof.
+    pose (X := BuildhSet (Tr 0 A)).
+    pose proof ((equiv_isprojective_choice X)^-1 (AC X)) as P.
+    pose proof (P A X idmap tr _) as F; clear P.
+    strip_truncations.
+    destruct F as [f p].
+    apply tr; refine (X; (f; _)).
+    unfold IsConnMap, IsConnected.
+    intro a.
+    rapply contr_inhabited_hprop.
+    unfold hfiber.
+    apply equiv_O_sigma_O.
+    refine (tr (tr a; _)).
+    rapply (equiv_path_Tr _ _)^-1%equiv.  (* Uses Univalence. *)
+    apply p.
+  Defined.
+
+  (** Assuming AC_(oo,-1), projective types are exactly sets. *)
+  Theorem equiv_isprojective_ishset_AC `{Univalence} (X : Type)
+    : IsProjective X <~> IsHSet X.
+  Proof.
+    apply equiv_iff_hprop.
+    - intro isprojX. unfold IsProjective in isprojX.
+      pose proof (projective_cover_AC X) as P; strip_truncations.
+      destruct P as [P [p issurj_p]].
+      pose proof (isprojX P X idmap p issurj_p) as S; strip_truncations.
+      destruct S as [s h].
+      rapply (istrunc_embedding_trunc s).
+      apply isembedding_isinj_hset.
+      exact (isinj_section h).
+    - intro ishsetX.
+      apply (equiv_isprojective_choice X)^-1.
+      rapply AC.
+  Defined.
+
+End AC_oo_neg1.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -191,6 +191,16 @@ Proof.
   apply H.
 Defined.
 
+(** A family of types is pointwise merely inhabited if and only if the corresponding fibration is surjective. *)
+(** * TODO Avoid univalence if equiv_forall_isconnmap_pr1 can. *)
+Lemma equiv_merely_issurjection `{Univalence} {X : Type} (P : X -> Type)
+  : (forall x, merely (P x)) <~> IsSurjection (pr1 : {x : X & P x} -> X).
+Proof.
+  refine (equiv_forall_isconnmap_pr1 _ oE _).
+  apply equiv_functor_forall_id; intro x.
+  exact (equiv_contr_hprop _)^-1%equiv.
+Defined.
+
 Definition isequiv_surj_emb {A B} (f : A -> B)
   `{IsSurjection f} `{IsEmbedding f}
   : IsEquiv f.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -192,11 +192,10 @@ Proof.
 Defined.
 
 (** A family of types is pointwise merely inhabited if and only if the corresponding fibration is surjective. *)
-(** * TODO Avoid univalence if equiv_forall_isconnmap_pr1 can. *)
-Lemma equiv_merely_issurjection `{Univalence} {X : Type} (P : X -> Type)
+Lemma equiv_merely_issurjection `{Funext} {X : Type} (P : X -> Type)
   : (forall x, merely (P x)) <~> IsSurjection (pr1 : {x : X & P x} -> X).
 Proof.
-  refine (equiv_forall_isconnmap_pr1 _ oE _).
+  refine (equiv_forall_isconnmap_pr1 _ _ oE _).
   apply equiv_functor_forall_id; intro x.
   exact (equiv_contr_hprop _)^-1%equiv.
 Defined.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -195,7 +195,7 @@ Defined.
 Lemma equiv_merely_issurjection `{Funext} {X : Type} (P : X -> Type)
   : (forall x, merely (P x)) <~> IsSurjection (pr1 : {x : X & P x} -> X).
 Proof.
-  refine (equiv_forall_isconnmap_pr1 _ _ oE _).
+  refine (equiv_forall_inO_fiber_pr1 (Conn _) _ oE _).
   apply equiv_functor_forall_id; intro x.
   exact (equiv_contr_hprop _)^-1%equiv.
 Defined.


### PR DESCRIPTION
Draft addressing the PR comments, in particular this one: https://github.com/HoTT/HoTT/pull/1393#discussion_r483177045

I've deduced `equiv_isconnmap_merely` (now renamed to `equiv_merely_issurjection` in `Truncations.Core`) from the general statements alluded to by MIke, found in `Modalities.ReflectiveSubuniverses`, if I understood correctly. Univalence gave me a quick proof of `equiv_forall_isconnmap_pr1` for now, but we should try to avoid it.