### PR TITLE
Classifying spaces and fibrations

### DIFF
--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -695,12 +695,12 @@ Definition Book_4_8_2 := @HoTT.HFiber.equiv_fibration_replacement.
 (* ================================================== thm:nobject-classifier-appetizer *)
 (** Theorem 4.8.3 *)
 
-Definition Book_4_8_3 := @HoTT.ObjectClassifier.FamequivPow.
+Definition Book_4_8_3 := @HoTT.ObjectClassifier.equiv_sigma_fibration.
 
 (* ================================================== thm:object-classifier *)
 (** Theorem 4.8.4 *)
 
-Definition Book_4_8_4 := @HoTT.ObjectClassifier.objclasspb_is_fibrantreplacement.
+Definition Book_4_8_4 := @HoTT.ObjectClassifier.ispullback_objectclassifier_square.
 
 (* ================================================== weakfunext *)
 (** Definition 4.9.1 *)

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -6,6 +6,7 @@ Require Import Pointed.
 Require Import ReflectiveSubuniverse Modality Modalities.Identity Modalities.Descent.
 Require Import Truncations.
 Require Import HFiber.
+Require Import ObjectClassifier.
 
 Local Open Scope succ_scope.
 Open Scope pointed_scope.
@@ -236,7 +237,7 @@ Global Instance isexact_pfib {X Y} (f : X ->* Y)
 Proof.
   exists (iscomplex_pfib f).
   exact _.
-Defined.    
+Defined.
 
 (** Fiber sequences can alternatively be defined as an equivalence to the fiber of some map. *)
 Definition FiberSeq (F X Y : pType) := { f : X ->* Y & F <~>* pfiber f }.
@@ -445,3 +446,16 @@ Definition Pi_les `{Univalence} {F X Y : pType} (i : F ->* X) (f : X ->* Y)
            `{IsExact purely F X Y i f}
   : LongExactSequence (Tr (-1)) (N3)
   := trunc_les (-1) (loops_les i f).
+
+(** * Classifying fiber sequences *)
+
+(** Fiber sequences correspond to pointed maps into the universe. *)
+Definition classify_fiberseq `{Univalence} {Y F : pType@{u}}
+  : (Y ->* Build_pType Type@{u} F) <~> { X : pType@{u} & FiberSeq F X Y }.
+Proof.
+  refine (_ oE _).
+  (** To apply [equiv_sigma_pfibration] we need to invert the equivalence on the fiber. *)
+  { do 2 (rapply equiv_functor_sigma_id; intro).
+    apply equiv_pequiv_inverse. }
+  exact ((equiv_sigma_assoc _ _)^-1 oE equiv_sigma_pfibration).
+Defined.

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -1,118 +1,189 @@
-(** We prove that Fam and Pow are equivalent.
-This equivalence is close to the existence of an object classifier.
-*)
+Require Import HoTT.Basics HoTT.Types HFiber Pullback Pointed Truncations.
+Require Import Modalities.ReflectiveSubuniverse.
 
-Require Import HoTT.Basics HoTT.Types.
-Require Import HFiber Pullback.
+Local Open Scope pointed_scope.
 
-Local Open Scope path_scope.
+(** * The object classifier *)
 
-Section AssumeUnivalence.
-Context `{ua:Univalence}.
+(** We prove that type families correspond to fibrations [equiv_sigma_fibration] (Theorem 4.8.3) and the projection [pointed_type : pType -> Type] is an object classifier [ispullback_square_objectclassifier] (Theorem 4.8.4). *)
 
-Section FamPow.
-(** We consider Families and Powers over a fixed type [A] *)
-Variable A : Type.
-Definition Fam A:=sig (fun I:Type  => I->A).
-Definition p2f: (A->Type)-> Fam A:=  fun Q:(A->Type) => ( (sig Q) ; @pr1 _ _).
-Definition f2p: Fam A -> (A->Type):=
- fun F => let (I, f) := F in (fun a => (hfiber f a)).
+(** We denote fibrations over a base [Y] as follows. *)
+Definition Fib (Y : Type@{u}) := { X : Type@{u} & X -> Y }.
+Definition pFib (Y : pType@{u}) := { X : pType@{u} & X ->* Y }.
 
-(* This is generalized in Functorish.v *)
-Theorem transport_exp (U V:Type)(w:U<~>V): forall (f:U->A),
-  (transport (fun I:Type => I->A) (path_universe w) f) = (f o w^-1).
+Definition sigma_fibration@{u v} {Y : Type@{u}} (P : Y -> Type@{u}) : Fib@{u v} Y
+  := (sig@{u u} P; pr1).
+
+(* This is generalized in Functorish.v. *)
+Theorem transport_exp `{Univalence} {A : Type} (U V : Type) (w : U <~> V)
+  : forall f : U -> A, transport (fun E : Type => E -> A) (path_universe w) f = (f o w^-1).
 Proof.
-  intros f; apply path_arrow; intros y.
+  intros f. funext y.
   refine (transport_arrow_toconst _ _ _ @ _).
   apply ap.
-  by apply transport_path_universe_V.
-Qed.
-
-Theorem FamequivPow : (A->Type)<~>(Fam A).
-Proof.
-apply (equiv_adjointify p2f f2p).
-(* Theorem right (F:Fam A) : F = (p2ff2p F) *)
- +intros [I f]. set (e:=equiv_path_sigma _ (@exist Type (fun I0 : Type => I0 -> A) I f)
-  ({a : A & hfiber f a} ; @pr1 _ _)). simpl in e.
-  enough (X:{p : I = {a : A & @hfiber I A f a} &
-     @transport _ (fun I0 : Type => I0 -> A) _ _ p f = @pr1 _ _}) by apply (e X)^.
-  set (w:=@equiv_fibration_replacement A I f).
-  exists (path_universe w). 
-  transitivity (f o w^-1);[apply transport_exp|apply path_forall;by (intros [a [i p]])].
- (* Theorem left (P:A -> Type) : (f2pp2f P) = P *)
- + intro P. by_extensionality a.
- apply ((path_universe (@hfiber_fibration  _ a P))^).
+  apply transport_path_universe_V.
 Defined.
 
-(** We construct the universal diagram for the object classifier *)
-Definition topmap {B} (f:B->A) (b:B): pType :=
-  Build_pType (hfiber f (f b)) (b ; idpath (f b)).
+Definition sigma_fibration_inverse {Y : Type@{u}} (p : Fib Y) : Y -> Type@{u}
+  := hfiber p.2.
 
-Local Definition help_objclasspb_is_fibrantreplacement (P:A-> Type): (sig P)->
-  (Pullback P (@pr1 _ (fun u :Type => u))):=
-(fun (X : {a : A & P a}) => (fun (a : A) (q : P a) => (a; ((P a; q); 1))) X.1 X.2).
-
-Local Definition help_objclasspb_is_fibrantreplacement2 (P:A-> Type):
- (Pullback P (@pr1 _ (fun u :Type => u))) -> (sig P).
-intros [a [[T t] p]]. exact (a;(transport (fun X => X) (p^) t)).
+Theorem isequiv_sigma_fibration `{Univalence} {Y : Type}
+  : IsEquiv (@sigma_fibration Y).
+Proof.
+  srapply isequiv_adjointify.
+  - exact sigma_fibration_inverse.
+  - intros [X p].
+    srapply path_sigma; cbn.
+    + exact (path_universe (equiv_fibration_replacement _)^-1%equiv).
+    + apply transport_exp.
+  - intro P.
+    funext y; cbn.
+    exact ((path_universe (@hfiber_fibration  _ y P))^).
 Defined.
 
-Lemma objclasspb_is_fibrantreplacement (P:A-> Type): (sig P) <~> (Pullback P (@pr1 _ (fun u :Type => u))).
+(** Theorem 4.8.3. *)
+Definition equiv_sigma_fibration `{Univalence} {Y : Type@{u}}
+  : (Y -> Type@{u}) <~> { X : Type@{u} & X -> Y }
+  := Build_Equiv _ _ (@sigma_fibration Y) isequiv_sigma_fibration.
+
+(** The universal map is the forgetful map [pointed_type : pType -> Type]. *)
+
+(** We construct the universal square for the object classifier. *)
+Local Definition topmap {A : Type} (P : A -> Type) (e : sig P) : pType
+  := Build_pType (P e.1) e.2.
+
+(** The square commutes definitionally. *)
+Definition objectclassifier_square {A : Type} (P : A -> Type)
+  : P o pr1 == pointed_type o (topmap P)
+  := fun e : sig P => idpath (P e.1).
+
+(** Theorem 4.8.4. *)
+Theorem ispullback_objectclassifier_square {A : Type} (P : A -> Type)
+  : IsPullback (objectclassifier_square P).
 Proof.
-exists (help_objclasspb_is_fibrantreplacement P).
-srapply isequiv_adjointify.
-- exact (help_objclasspb_is_fibrantreplacement2 P).
-- intros [a [[T t] p]].
-  refine (path_sigma' _ (idpath a) _).
-  simpl in p. by path_induction.
-- intros [a p]; apply idpath.
+  srapply isequiv_adjointify.
+  - intros [a [F p]].
+    exact (a; transport idmap p^ (point F)).
+  - intros [a [[T t] p]]; cbn in p.
+    refine (path_sigma' _ (idpath a) _).
+    by induction p.
+  - reflexivity.
 Defined.
 
-End FamPow.
+(** ** Classifying fibrations with specified fiber *)
 
-Section Subobjectclassifier.
-(** We prove that hProp is the subobject classifier *)
-(** In fact, the proof works for general mere predicates on [Type], 
-not just [IsHProp], truncations and modalities are important examples.*)
-Variable A : Type.
-Variable isP : Type -> Type.
-Variable ishprop_isP : forall I, IsHProp (isP I).
-Definition IsPfibered {I} (f:I->A):=forall i, isP (hfiber f i).
-Definition PFam := (sig (fun F:Fam A => IsPfibered (pr2 F))).
-(* Bug: abstract should accept more than one tactic.
-https://coq.inria.fr/bugs/show_bug.cgi?id=3609
-Alternatively, we would like to use [Program] here.
-6a99db1c31fe267fdef7be755fa169fb6a87e3cf
-Instead we split the [Definition] and first make a [Local Definition] *)
-Local Definition pow2Pfam_pf (P:forall a:A, {X :Type & isP X}): 
-           IsPfibered (pr2 (p2f A (pr1 o P))). 
+Local Notation "( X , x )" := (Build_pType X x).
+
+(** Fibrations over [B] with fiber [F] correspond to pointed maps into the universe pointed at [F]. *)
+Proposition equiv_sigma_fibration_p@{u +} `{Univalence} {Y : pType@{u}} {F : Type@{u}}
+  : (Y ->* (Type@{u}, F)) <~> { p : Fib@{u v} Y & hfiber p.2 (point Y) <~> F }.
 Proof.
-intro i. cbn. 
-rewrite <- (path_universe_uncurried (@hfiber_fibration A i (pr1 o P))).
-apply ((P i).2).
-Qed.
-
-Definition pow2Pfam (P:forall a:A, {X :Type & isP X}): PFam:=
-  (p2f A (fun a => (pr1 (P a))); pow2Pfam_pf P).
-
-Local Definition Pfam2pow_pf (F:PFam)(a:A):isP (f2p A F.1 a). 
-unfold f2p. by destruct F as [[I f] p].
-Qed.
-
-Definition Pfam2pow (F:PFam) (a:A): {X :Type & isP X}:=
-   ((f2p A F.1 a); (Pfam2pow_pf F a)).
-
-Theorem PowisoPFam : (forall a:A, {X :Type & isP X})<~>PFam.
-Proof.
-apply (equiv_adjointify pow2Pfam Pfam2pow).
- + intros [[B f] q]. apply path_sigma_hprop. cbn.
-  refine (@eisretr _ _ (FamequivPow A) _ (B;f)).
-+ intro P. apply path_forall. intro a.
- assert (f2p A (p2f A (pr1 o P)) a = (pr1 (P a))).
-- set (p:=@eissect _ _ (FamequivPow A) _).
-  apply (ap10 (p (pr1 o P)) a).
-- by apply path_sigma_hprop.
+  refine (_ oE (issig_pmap _ _)^-1).
+  srapply (equiv_functor_sigma' equiv_sigma_fibration); intro P; cbn.
+  refine (_ oE (equiv_path_universe@{u u v} _ _)^-1%equiv).
+  refine (equiv_functor_equiv _ equiv_idmap).
+  apply hfiber_fibration.
 Defined.
-End Subobjectclassifier.
 
-End AssumeUnivalence.
+(** If the fiber [F] is pointed we may upgrade the right-hand side to fiber sequences. *)
+Lemma equiv_pfiber_fibration_pfibration@{u v} {Y F : pType@{u}}
+  : { p : Fib@{u v} Y & hfiber p.2 (point Y) <~> F}
+      <~> { p : pFib@{u v} Y & pfiber p.2 <~>* F }.
+Proof.
+  equiv_via
+    (sig@{v u} (fun X : Type@{u} =>
+                  { x : X &
+                        { p : X -> Y &
+                                  { eq : p x = point Y &
+                                         { e : hfiber p (point Y) <~> F
+                                               & e^-1 (point F) = (x; eq) } } } })).
+  - refine (_ oE _).
+    + do 5 (rapply equiv_functor_sigma_id; intro).
+      apply equiv_path_sigma.
+    + make_equiv_contr_basedpaths.
+  - refine (_ oE _).
+    2: { do 5 (rapply equiv_functor_sigma_id; intro).
+         exact (equiv_path_inverse _ _ oE equiv_moveL_equiv_M _ _). }
+    make_equiv.
+Defined.
+
+Definition equiv_sigma_pfibration `{Univalence} {Y F : pType@{u}}
+  : (Y ->* (Type@{u}, F)) <~> { p : pFib Y & pfiber p.2 <~>* F}
+  := equiv_pfiber_fibration_pfibration oE equiv_sigma_fibration_p.
+
+(** * The classifier for O-local types *)
+
+(** Families of O-local types correspond to fibrations with O-local fibers. *)
+Theorem equiv_sigma_fibration_O@{u v} `{Univalence} {O : Subuniverse} {A : Type@{u}}
+  : (A -> Type_@{u v} O) <~> { p : { X : Type@{u} & X -> A } & MapIn O p.2 }.
+Proof.
+  refine (_ oE (equiv_sig_coind _ _)^-1).
+  apply (equiv_functor_sigma' equiv_sigma_fibration); intro P; cbn.
+  rapply equiv_forall_inO_mapinO_pr1.
+Defined.
+
+(** ** Classifying O-local fibrations with specified fiber *) 
+
+(** We consider a pointed base [Y], and the universe of O-local types [Type_ O] pointed at some O-local type [F]. *)
+
+(** Pointed maps into [Type_ O] correspond to O-local fibrations with fiber [F] over the base point of [Y]. *)
+Proposition equiv_sigma_fibration_Op `{Univalence} {O : Subuniverse}
+            {Y : pType@{u}} {F : Type@{u}} `{inO : In O F}
+  : (Y ->* (Type_ O, (F; inO)))
+      <~> { p : { p : Fib Y & MapIn O p.2 } & hfiber p.1.2 (point Y) <~> F }.
+Proof.
+  refine (_ oE (issig_pmap _ _)^-1); cbn.
+  srapply (equiv_functor_sigma' equiv_sigma_fibration_O); intro P; cbn.
+  refine (_ oE (equiv_path_sigma_hprop _ _)^-1%equiv); cbn.
+  refine (_ oE (equiv_path_universe _ _)^-1%equiv).
+  refine (equiv_functor_equiv _ equiv_idmap).
+  exact (hfiber_fibration (point Y) _).
+Defined.
+
+(** When the base [Y] is connected, the fibers being O-local follow from the fact that the fiber [F] over the base point is. *)
+Proposition equiv_sigma_fibration_Op_connected `{Univalence} {O : Subuniverse}
+            {Y : pType@{u}} `{IsConnected 0 Y} {F : Type@{u}} `{inO : In O F}
+  : (Y ->* (Type_ O, (F; inO)))
+       <~> { p : Fib Y & hfiber p.2 (point Y) <~> F }.
+Proof.
+  refine (_ oE equiv_sigma_fibration_Op).
+  refine (_ oE (equiv_sigma_assoc' _ (fun p _ => hfiber p.2 (point Y) <~> F))^-1%equiv).
+  srapply equiv_functor_sigma_id; intro; cbn.
+  refine (_ oE equiv_sigma_prod0 _ _).
+  apply equiv_prod_contr_l; intro e.
+  rapply contr_inhabited_hprop.
+  apply (mapinO_inO_fiber_connected _ (point Y)).
+  apply (inO_equiv_inO F e^-1).
+Defined.
+
+(** *** Classifying O-local fibrations with specified pointed fiber *)
+
+(** When the fiber [F] is pointed, the right-hand side can be upgraded to fiber sequences with O-local fibers.  *)
+Proposition equiv_sigma_pfibration_O `{Univalence} (O : Subuniverse)
+            {Y F : pType} `{inO : In O F}
+  : (Y ->* (Type_ O, (pointed_type F; inO)))
+      <~> { p : { p : pFib Y & MapIn O p.2 } & pfiber p.1.2 <~>* F }.
+Proof.
+  refine (_ oE equiv_sigma_fibration_Op).
+  (** We juggle the [MapIn O] term to the outermost sigma. *)
+  refine (equiv_sigma_assoc _ _ oE _ oE (equiv_sigma_assoc _ _)^-1).
+  refine ((_)^-1 oE _ oE _).
+  1,3: rapply equiv_functor_sigma_id; unfold pr1; intro p; apply equiv_sigma_symm0.
+  refine (_ oE equiv_sigma_assoc _ (fun p => MapIn _ p.1.2)).
+  refine ((equiv_sigma_assoc _ (fun p:({ p : pFib Y & pfiber p.2 <~>* F }) => MapIn _ p.1.2))^-1 oE _).
+  (** Now it's just [equiv_pfiber_fibration_pfibration] on the base, and reflexivity on the fibers. *)
+  by rapply (equiv_functor_sigma' equiv_pfiber_fibration_pfibration).
+Defined.
+
+(** When moreover the base [Y] is connected, the right-hand side are exactly fiber sequences, since the fibers being O-local follow from [F] being O-local and [Y] connected. *)
+Definition equiv_sigma_pfibration_O_connected `{Univalence} (O : Subuniverse)
+          {Y F : pType} `{IsConnected 0 Y} `{inO : In O F}
+  : (Y ->* (Type_ O, (pointed_type F; inO)))
+      <~> { p : pFib Y & pfiber p.2 <~>* F }
+  := equiv_pfiber_fibration_pfibration oE equiv_sigma_fibration_Op_connected.
+
+(** As a corollary, pointed maps into the unverse of O-local types are just pointed maps into the universe, when the base [Y] is connected. *)
+Definition equiv_pmap_typeO_type_connected `{Univalence} {O : Subuniverse}
+      {Y : pType@{u}} `{IsConnected 0 Y} {F : Type@{u}} `{inO : In O F}
+  : (Y ->* (Type_ O, (F; inO))) <~> (Y ->* (Type@{u}, F))
+  := equiv_sigma_fibration_p^-1 oE equiv_sigma_fibration_Op_connected.

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -114,5 +114,23 @@ Definition equiv_pequiv_precompose `{Funext} {A B C : pType} (f : A <~>* B)
   := equiv_precompose_cat_equiv f.
 
 Definition equiv_pequiv_postcompose `{Funext} {A B C : pType} (f : B <~>* C)
-  : (A ->* B) <~> (A ->* C)
-  := equiv_postcompose_cat_equiv f.
+  : (A ->* B) <~> (A ->* C).
+Proof.
+  srapply equiv_adjointify.
+  - exact (fun g => f o* g).
+  - exact (fun g => f^-1* o* g).
+  - intro g.
+    apply path_pforall.
+    by apply moveR_pequiv_Mf.
+  - intro g.
+    apply path_pforall.
+    by apply moveR_pequiv_Vf.
+Defined.
+
+Proposition equiv_pequiv_inverse `{Funext} {A B : pType}
+  : (A <~>* B) <~> (B <~>* A).
+Proof.
+  refine (issig_pequiv' _ _ oE _ oE (issig_pequiv' A B)^-1).
+  srapply (equiv_functor_sigma' (equiv_equiv_inverse _ _)); intro e; cbn.
+  exact (equiv_moveR_equiv_V _ _ oE equiv_path_inverse _ _).
+Defined.

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -2,7 +2,9 @@
 Require Import HoTT.Basics HoTT.Types HProp.
 Require Import Constant Factorization.
 Require Import Modalities.Modality HoTT.Truncations.
+Require Import ObjectClassifier Homotopy.ExactSequence Pointed.
 
+Local Open Scope type_scope.
 Local Open Scope path_scope.
 
 (** * BAut(X) *)
@@ -10,13 +12,15 @@ Local Open Scope path_scope.
 (** ** Basics *)
 
 (** [BAut X] is the type of types that are merely equal to [X]. It is connected, by [is0connected_component]. *)
-Definition BAut@{u v} (X : Type@{u}) : Type@{v}
-  := sig@{v v} (fun Z => merely (paths@{v} Z X)).
+Definition BAut (X : Type@{u}) := { Z : Type@{u} & merely (Z = X) }.
+
+Coercion BAut_pr1 X : BAut X -> Type := pr1.
 
 Global Instance ispointed_baut {X : Type} : IsPointed (BAut X) := (X; tr 1).
 
-Definition BAut_pr1 X : BAut X -> Type := pr1.
-Coercion BAut_pr1 : BAut >-> Sortclass.
+(** We also define a pointed version [pBAut X], since the coercion [BAut_pr1] doesn't work if [BAut X] is a [pType]. *)
+Definition pBAut (X : Type) : pType
+  := Build_pType (BAut X) _.
 
 Definition path_baut `{Univalence} {X} (Z Z' : BAut X)
 : (Z <~> Z') <~> (Z = Z' :> BAut X)
@@ -236,3 +240,68 @@ Section Center2BAut.
   Defined.
 
 End Center2BAut.
+
+Section ClassifyingMaps.
+
+  (** ** Maps into [BAut F] classify fibrations with fiber [F] *)
+
+  (** The property of being merely equivalent to a given type [F] defines a subuniverse. *)
+  Definition subuniverse_merely_equiv (F : Type) : Subuniverse.
+  Proof.
+    rapply (Build_Subuniverse (fun E => merely (E <~> F))).
+    intros T U mere_eq f iseq_f.
+    strip_truncations.
+    pose (feq:=Build_Equiv _ _ f iseq_f).
+    exact (tr (mere_eq oE feq^-1)).
+  Defined.
+
+  (** The universe of O-local types for [subuniverse_merely_equiv F] is equivalent to [BAut F]. *)
+  Proposition equiv_baut_typeO `{Univalence} {F : Type}
+    :  BAut F <~> Type_ (subuniverse_merely_equiv F).
+  Proof.
+    srapply equiv_functor_sigma_id; intro X; cbn.
+    rapply Trunc_functor_equiv.
+    exact (equiv_path_universe _ _)^-1%equiv.
+  Defined.
+
+  (** Consequently, maps into [BAut F] correspond to fibrations with fibers merely equivalent to [F]. *)
+  Corollary equiv_map_baut_fibration `{Univalence} {Y : pType} {F : Type}
+    : (Y -> BAut F) <~> { p : Fib Y & forall y:Y, merely (hfiber p.2 y <~> F) }.
+  Proof.
+    refine (_ oE equiv_postcompose' equiv_baut_typeO).
+    refine (_ oE equiv_sigma_fibration_O).
+    snrapply equiv_functor_sigma_id; intro p.
+    rapply equiv_functor_forall_id; intro y.
+    by apply Trunc_functor_equiv.
+  Defined.
+
+  (** The pointed version of [equiv_baut_typeO] above. *)
+  Proposition pequiv_pbaut_typeOp `{Univalence} {F : Type@{u}}
+    : pBAut F <~>* Build_pType (Type_@{u v} (subuniverse_merely_equiv F)) (F; tr equiv_idmap).
+  Proof.
+    snrapply Build_pEquiv'; cbn.
+    1: exact equiv_baut_typeO.
+    by apply path_sigma_hprop.
+  Defined.
+
+  Definition equiv_pmap_pbaut_pfibration `{Univalence} {Y F : pType@{u}}
+    : (Y ->* pBAut F) <~> { p : { p : pFib Y & forall y:Y, merely (hfiber p.2 y <~> F) } &
+                                pfiber p.1.2 <~>* F }
+    := (equiv_sigma_pfibration_O (subuniverse_merely_equiv F))
+         oE equiv_pequiv_postcompose pequiv_pbaut_typeOp.
+
+  (** When [Y] is connected, pointed maps into [pBAut F] correspond to maps into the universe sending the base point to [F]. *)
+  Proposition equiv_pmap_pbaut_type_p `{Univalence}
+              {Y : pType@{u}} {F : Type@{u}} `{IsConnected 0 Y}
+    : (Y ->* pBAut F) <~> (Y ->* Build_pType Type@{u} F).
+  Proof.
+    refine (_ oE equiv_pequiv_postcompose pequiv_pbaut_typeOp).
+    by apply equiv_pmap_typeO_type_connected.
+  Defined.
+
+  (** When [Y] is connected, [pBAut F] classifies fiber sequences over [B] with fiber [F]. *)
+  Definition equiv_pmap_pbaut_pfibration_connected `{Univalence} {Y F : pType} `{IsConnected 0 Y}
+    : (Y ->* pBAut F) <~> { X : pType & FiberSeq F X Y }
+    := classify_fiberseq oE equiv_pmap_pbaut_type_p.
+
+End ClassifyingMaps.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -192,6 +192,18 @@ Proof.
     exact (center (merely X)).
 Defined.
 
+(** If the fiber of a map into a pointed, connected type is O-local, then the map is O-local. *)
+Lemma mapinO_inO_fiber_connected@{u v} `{Univalence} (O : Subuniverse)
+      {A B : Type@{u}} (b0 : B) `{IsConnected 0 B} (f : A -> B)
+  : In O (hfiber f b0) -> MapIn O f.
+Proof.
+  intros inO b.
+  assert (p : merely (b0 = b))
+    by rapply merely_path_is0connected@{u v u u u u u u u}.
+  strip_truncations.
+  by apply (transport (In O o hfiber f) p).
+Defined.
+
 (* Truncation preserves connectedness. Note that this is for different levels. *)
 Global Instance isconnected_trunc {X : Type} (n m : trunc_index) `{IsConnected n X}
   : IsConnected n (Tr m X).

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -260,6 +260,28 @@ Definition equiv_functor_prod_r {A A' B : Type} (f : A <~> A')
   : A * B <~> A' * B
   := f *E 1.
 
+Definition equiv_prod_contr_l {A B : Type} (C : B -> Contr A)
+  : A * B <~> B.
+Proof.
+  srapply (equiv_adjointify snd (fun b => (@center A (C b), b))).
+  1: reflexivity.
+  intro x.
+  apply path_prod; cbn.
+  - apply (C (snd x)).
+  - reflexivity.
+Defined.
+
+Definition equiv_prod_contr_r {A B : Type} (C : A -> Contr B)
+  : A * B <~> A.
+Proof.
+  srapply (equiv_adjointify fst (fun a => (a, @center B (C a)))).
+  1: reflexivity.
+  intro x.
+  apply path_prod; cbn.
+  1: reflexivity.
+  apply (C (fst x)).
+Defined.
+
 (** ** Logical equivalences *)
 
 Definition iff_functor_prod {A A' B B' : Type} (f : A <-> A') (g : B <-> B')


### PR DESCRIPTION
Complete rewrite and expansion of `ObjectClassifier.v` in the first commit. (Recommend using split view, since the diff isn't great.) In the second commit these results are used to classify fiber sequences and maps into `BAut X`. Some comments:

In `ObjectClassifier.v`, the statements involving pointed maps use 3 universes instead of the 2 required on paper. This is because`pMap` is defined via `pForall`, whereas if we'd used something like
```coq
Definition pMap A B := { f : A -> B & f (point A) = B }.
```
then these statements should only require 2 universes. I managed to squash it down to 2 in `equiv_pfiber_fibration_pfibration`, but haven't been able to (and doubt it's possible) elsewhere.

I've chosen to work with the right endpoint fixed on the equivalence on fibers, in order to correspond with the paths in `hfiber` and the paths in the current definition of `BAut`. This makes `equiv_pfiber_pfibration_fibration` a bit more fiddly than otherwise, and also doesn't correspond to the choice for `FiberSeq`. But otherwise it seemed to make things flow most nicely.

At the end of `ObjectClassifier.v`, I'm sure `equiv_pmap_typeO_type_connected` can be proved more directly without univalence.


