### PR TITLE
Path Spaces of Pushouts

### DIFF
--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -413,6 +413,8 @@ Definition equiv_ap_inv' `(f : A <~> B) (x y : B)
   : (f^-1 x = f^-1 y) <~> (x = y)
   := (equiv_ap' f^-1%equiv x y)^-1%equiv.
 
+(** We define the 2-out-of-3 property, or 2 for 3 property *)
+
 (** If [g \o f] and [f] are equivalences, so is [g].  This is not an Instance because it would require Coq to guess [f]. *)
 Definition cancelR_isequiv {A B C} (f : A -> B) {g : B -> C}
   `{IsEquiv A B f} `{IsEquiv A C (g o f)}
@@ -456,6 +458,58 @@ Definition isequiv_commsq' {A B C D}
 Proof.
   refine (@cancelL_isequiv _ _ _ k f _ _).
   refine (isequiv_homotopic _ p).
+Defined.
+
+(** We define the 2-out-of-6 property *)
+
+Definition two_out_of_six_snd {A B C D}
+  (f : A -> B) (g : B -> C) (h : C -> D)
+  `{IsEquiv _ _ (g o f)} `{IsEquiv _ _ (h o g)}
+  : IsEquiv g.
+Proof.
+  destruct H as [gf_inv gf_s gf_r gf_adj].
+  destruct H0 as [hg_inv hg_s hg_r hg_adj].
+  snrapply isequiv_adjointify.
+  - exact (hg_inv o h).
+  - Check (fun x => ap (hg_inv o h) (gf_s x)^). 
+    exact (fun x => ap g (ap (hg_inv o h) (gf_s x)^ @ hg_r ((f o gf_inv) x)) @ gf_s x).
+  - exact hg_r.
+Defined.
+
+Definition two_out_of_six_fst {A B C D}
+  (f : A -> B) (g : B -> C) (h : C -> D)
+  `{IsEquiv _ _ (g o f)} `{IsEquiv _ _ (h o g)}
+  : IsEquiv f.
+Proof.
+  snrapply cancelL_isequiv.
+  - exact C.
+  - exact g.
+  - exact (two_out_of_six_snd f g h).
+  - exact H.
+Defined.
+
+Definition two_out_of_six_thr {A B C D}
+  (f : A -> B) (g : B -> C) (h : C -> D)
+  `{IsEquiv _ _ (g o f)} `{IsEquiv _ _ (h o g)}
+  : IsEquiv h.
+Proof.
+  snrapply cancelR_isequiv.
+  - exact B.
+  - exact g.
+  - exact (two_out_of_six_snd f g h).
+  - exact H0.
+Defined.
+
+Definition two_out_of_six {A B C D}
+  (f : A -> B) (g : B -> C) (h : C -> D)
+  `{IsEquiv _ _ (g o f)} `{IsEquiv _ _ (h o g)}
+  : IsEquiv f * IsEquiv g * IsEquiv h.
+Proof.
+  split.
+  - split.
+    + exact (two_out_of_six_fst f g h).
+    + exact (two_out_of_six_snd f g h).
+  - exact (two_out_of_six_thr f g h).
 Defined.
 
 (** Based homotopy spaces *)

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -462,55 +462,30 @@ Defined.
 
 (** We define the 2-out-of-6 property *)
 
-Definition two_out_of_six_snd {A B C D}
+Definition two_out_of_sixM {A B C D}
   (f : A -> B) (g : B -> C) (h : C -> D)
-  `{IsEquiv _ _ (g o f)} `{IsEquiv _ _ (h o g)}
+  `{iegf : IsEquiv _ _ (g o f)} `{iehg : IsEquiv _ _ (h o g)}
   : IsEquiv g.
 Proof.
-  destruct H as [gf_inv gf_s gf_r gf_adj].
-  destruct H0 as [hg_inv hg_s hg_r hg_adj].
   snrapply isequiv_adjointify.
-  - exact (hg_inv o h).
-  - Check (fun x => ap (hg_inv o h) (gf_s x)^). 
-    exact (fun x => ap g (ap (hg_inv o h) (gf_s x)^ @ hg_r ((f o gf_inv) x)) @ gf_s x).
-  - exact hg_r.
+  - exact ((h o g)^-1 o h).
+  - exact (fun x => ap g (ap ((h o g)^-1 o h) ((eisretr (g o f)) x)^ 
+    @ (eissect (h o g)) ((f o (g o f)^-1) x)) 
+    @ (eisretr (g o f)) x).
+  - exact (eissect (h o g)).
 Defined.
 
-Definition two_out_of_six_fst {A B C D}
+Definition two_out_of_sixR {A B C D}
   (f : A -> B) (g : B -> C) (h : C -> D)
   `{IsEquiv _ _ (g o f)} `{IsEquiv _ _ (h o g)}
-  : IsEquiv f.
-Proof.
-  snrapply cancelL_isequiv.
-  - exact C.
-  - exact g.
-  - exact (two_out_of_six_snd f g h).
-  - exact H.
-Defined.
+  : IsEquiv f
+  := @cancelL_isequiv _ _ _ g _ (two_out_of_sixM f g h) _.
 
-Definition two_out_of_six_thr {A B C D}
+Definition two_out_of_sixL {A B C D}
   (f : A -> B) (g : B -> C) (h : C -> D)
   `{IsEquiv _ _ (g o f)} `{IsEquiv _ _ (h o g)}
-  : IsEquiv h.
-Proof.
-  snrapply cancelR_isequiv.
-  - exact B.
-  - exact g.
-  - exact (two_out_of_six_snd f g h).
-  - exact H0.
-Defined.
-
-Definition two_out_of_six {A B C D}
-  (f : A -> B) (g : B -> C) (h : C -> D)
-  `{IsEquiv _ _ (g o f)} `{IsEquiv _ _ (h o g)}
-  : IsEquiv f * IsEquiv g * IsEquiv h.
-Proof.
-  split.
-  - split.
-    + exact (two_out_of_six_fst f g h).
-    + exact (two_out_of_six_snd f g h).
-  - exact (two_out_of_six_thr f g h).
-Defined.
+  : IsEquiv h
+  := @cancelR_isequiv _ _ _ g _ (two_out_of_sixM f g h) _.
 
 (** Based homotopy spaces *)
 

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -222,6 +222,48 @@ Section FunctorialityColimit.
       = cocone_postcompose HQ1 (functor_colimit m HQ1 HQ2)
     := (eisretr (cocone_postcompose HQ1) _)^.
 
+  (** Additional coherence with postcompose and precompose *)
+
+  Definition cocone_precompose_postcompose_comp {D1 D2 : Diagram G}
+    (m : DiagramMap D1 D2) {Q1 Q2 : Type} (HQ1 : IsColimit D1 Q1)
+    (HQ2 : IsColimit D2 Q2) {T : Type} (t : Q2 -> T)
+    : cocone_postcompose HQ1 (t o (functor_colimit m HQ1 HQ2))
+      = cocone_precompose m (cocone_postcompose HQ2 t).
+    Proof.
+      rewrite (cocone_postcompose_comp (functor_colimit m _ _) _ _).
+      rewrite <- (functor_colimit_commute m HQ1 HQ2).
+      rewrite (cocone_precompose_postcompose m t HQ2).
+      reflexivity.
+    Defined.
+
+  (** Functoriality of colimit *)
+
+  Definition pre_functoriality_functor_colimit {D1 D2 D3 : Diagram G} 
+    (m : DiagramMap D1 D2) (n : DiagramMap D2 D3) 
+    {Q1 Q2 Q3} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
+    (HQ3 : IsColimit D3 Q3)
+    : cocone_postcompose HQ1 ((functor_colimit n HQ2 HQ3) o (functor_colimit m HQ1 HQ2))
+      = cocone_postcompose HQ1 (functor_colimit (diagram_comp n m) HQ1 HQ3).
+    Proof.
+      rewrite (cocone_precompose_postcompose_comp m HQ1 HQ2 _).
+      rewrite <- (functor_colimit_commute n HQ2 HQ3).
+      rewrite (cocone_precompose_comp n m _).
+      rewrite (functor_colimit_commute (diagram_comp n m) _ _).
+      reflexivity.
+    Defined.
+
+  Definition functoriality_functor_colimit {D1 D2 D3 : Diagram G} 
+    (m : DiagramMap D1 D2) (n : DiagramMap D2 D3) 
+    {Q1 Q2 Q3} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
+    (HQ3 : IsColimit D3 Q3)
+    : (functor_colimit n HQ2 HQ3) o (functor_colimit m HQ1 HQ2)
+      = (functor_colimit (diagram_comp n m) HQ1 HQ3).
+    Proof.
+      apply (@equiv_inj _ _ 
+        (cocone_postcompose HQ1) (iscolimit_unicocone HQ1 Q3) _ _ 
+        (pre_functoriality_functor_colimit m n HQ1 HQ2 HQ3)).
+    Defined.
+
   (** ** Colimits of equivalent diagrams *)
 
   (** Now we have than two equivalent diagrams have equivalent colimits. *)

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -230,13 +230,14 @@ Section FunctorialityColimit.
     : cocone_postcompose HQ1 (t o (functor_colimit m HQ1 HQ2))
       = cocone_precompose m (cocone_postcompose HQ2 t).
     Proof.
-      rewrite (cocone_postcompose_comp (functor_colimit m _ _) _ _).
-      rewrite <- (functor_colimit_commute m HQ1 HQ2).
-      rewrite (cocone_precompose_postcompose m t HQ2).
+      lhs refine (cocone_postcompose_comp (functor_colimit m _ _) _ _).
+      lhs refine (ap (fun x => cocone_postcompose x t) 
+        (functor_colimit_commute m HQ1 HQ2)^).
+      lhs refine (cocone_precompose_postcompose m t HQ2).
       reflexivity.
     Defined.
 
-  (** Functoriality of colimit *)
+  (** Functoriality of colimits *)
 
   Definition pre_functoriality_functor_colimit {D1 D2 D3 : Diagram G} 
     (m : DiagramMap D1 D2) (n : DiagramMap D2 D3) 
@@ -244,13 +245,13 @@ Section FunctorialityColimit.
     (HQ3 : IsColimit D3 Q3)
     : cocone_postcompose HQ1 ((functor_colimit n HQ2 HQ3) o (functor_colimit m HQ1 HQ2))
       = cocone_postcompose HQ1 (functor_colimit (diagram_comp n m) HQ1 HQ3).
-    Proof.
-      rewrite (cocone_precompose_postcompose_comp m HQ1 HQ2 _).
-      rewrite <- (functor_colimit_commute n HQ2 HQ3).
-      rewrite (cocone_precompose_comp n m _).
-      rewrite (functor_colimit_commute (diagram_comp n m) _ _).
-      reflexivity.
-    Defined.
+  Proof.
+    lhs refine (cocone_precompose_postcompose_comp m HQ1 HQ2 _).
+    lhs refine (ap _ (functor_colimit_commute n HQ2 HQ3)^).
+    lhs refine (cocone_precompose_comp n m _ HQ3).
+    lhs refine (functor_colimit_commute (diagram_comp n m) _ _).
+    reflexivity.
+  Defined.
 
   Definition functoriality_functor_colimit {D1 D2 D3 : Diagram G} 
     (m : DiagramMap D1 D2) (n : DiagramMap D2 D3) 
@@ -258,11 +259,11 @@ Section FunctorialityColimit.
     (HQ3 : IsColimit D3 Q3)
     : (functor_colimit n HQ2 HQ3) o (functor_colimit m HQ1 HQ2)
       = (functor_colimit (diagram_comp n m) HQ1 HQ3).
-    Proof.
-      apply (@equiv_inj _ _ 
-        (cocone_postcompose HQ1) (iscolimit_unicocone HQ1 Q3) _ _ 
-        (pre_functoriality_functor_colimit m n HQ1 HQ2 HQ3)).
-    Defined.
+  Proof.
+    apply (@equiv_inj _ _ 
+      (cocone_postcompose HQ1) (iscolimit_unicocone HQ1 Q3) _ _ 
+      (pre_functoriality_functor_colimit m n HQ1 HQ2 HQ3)).
+  Defined.
 
   (** ** Colimits of equivalent diagrams *)
 

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -239,7 +239,7 @@ Section FunctorialityColimit.
 
   (** Functoriality of colimits *)
 
-  Definition pre_functoriality_functor_colimit {D1 D2 D3 : Diagram G} 
+  Definition postcompose_functor_colimit_compose {D1 D2 D3 : Diagram G} 
     (m : DiagramMap D1 D2) (n : DiagramMap D2 D3) 
     {Q1 Q2 Q3} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
     (HQ3 : IsColimit D3 Q3)
@@ -253,7 +253,7 @@ Section FunctorialityColimit.
     reflexivity.
   Defined.
 
-  Definition functoriality_functor_colimit {D1 D2 D3 : Diagram G} 
+  Definition functor_colimit_compose {D1 D2 D3 : Diagram G} 
     (m : DiagramMap D1 D2) (n : DiagramMap D2 D3) 
     {Q1 Q2 Q3} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
     (HQ3 : IsColimit D3 Q3)
@@ -262,7 +262,7 @@ Section FunctorialityColimit.
   Proof.
     apply (@equiv_inj _ _ 
       (cocone_postcompose HQ1) (iscolimit_unicocone HQ1 Q3) _ _ 
-      (pre_functoriality_functor_colimit m n HQ1 HQ2 HQ3)).
+      (postcompose_functor_colimit_compose m n HQ1 HQ2 HQ3)).
   Defined.
 
   (** ** Colimits of equivalent diagrams *)

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -228,13 +228,12 @@ Section FunctorialityColimit.
     (m : DiagramMap D1 D2) {Q1 Q2 : Type} (HQ1 : IsColimit D1 Q1)
     (HQ2 : IsColimit D2 Q2) {T : Type} (t : Q2 -> T)
     : cocone_postcompose HQ1 (t o (functor_colimit m HQ1 HQ2))
-      = cocone_precompose m (cocone_postcompose HQ2 t).
+    = cocone_precompose m (cocone_postcompose HQ2 t).
     Proof.
-      lhs refine (cocone_postcompose_comp (functor_colimit m _ _) _ _).
-      lhs_V refine (ap (fun x => cocone_postcompose x t) 
+      lhs nrapply cocone_postcompose_comp.
+      lhs_V exact (ap (fun x => cocone_postcompose x t) 
         (functor_colimit_commute m HQ1 HQ2)).
-      lhs refine (cocone_precompose_postcompose m t HQ2).
-      reflexivity.
+      snrapply cocone_precompose_postcompose.
     Defined.
 
   (** Functoriality of colimits *)
@@ -244,13 +243,12 @@ Section FunctorialityColimit.
     {Q1 Q2 Q3} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
     (HQ3 : IsColimit D3 Q3)
     : cocone_postcompose HQ1 ((functor_colimit n HQ2 HQ3) o (functor_colimit m HQ1 HQ2))
-      = cocone_postcompose HQ1 (functor_colimit (diagram_comp n m) HQ1 HQ3).
+    = cocone_postcompose HQ1 (functor_colimit (diagram_comp n m) HQ1 HQ3).
   Proof.
-    lhs refine (cocone_precompose_postcompose_comp m HQ1 HQ2 _).
-    lhs_V refine (ap _ (functor_colimit_commute n HQ2 HQ3)).
-    lhs refine (cocone_precompose_comp n m _ HQ3).
-    lhs refine (functor_colimit_commute (diagram_comp n m) _ _).
-    reflexivity.
+    lhs nrapply cocone_precompose_postcompose_comp.
+    lhs_V nrapply (ap _ (functor_colimit_commute n HQ2 HQ3)).
+    lhs nrapply cocone_precompose_comp.
+    snrapply functor_colimit_commute.
   Defined.
 
   Definition functor_colimit_compose {D1 D2 D3 : Diagram G} 
@@ -258,8 +256,8 @@ Section FunctorialityColimit.
     {Q1 Q2 Q3} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
     (HQ3 : IsColimit D3 Q3)
     : (functor_colimit n HQ2 HQ3) o (functor_colimit m HQ1 HQ2)
-      = (functor_colimit (diagram_comp n m) HQ1 HQ3) 
-  :=  @equiv_inj _ _ 
+    = (functor_colimit (diagram_comp n m) HQ1 HQ3) 
+  := @equiv_inj _ _ 
       (cocone_postcompose HQ1) (iscolimit_unicocone HQ1 Q3) _ _ 
       (postcompose_functor_colimit_compose m n HQ1 HQ2 HQ3).
 

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -231,8 +231,8 @@ Section FunctorialityColimit.
       = cocone_precompose m (cocone_postcompose HQ2 t).
     Proof.
       lhs refine (cocone_postcompose_comp (functor_colimit m _ _) _ _).
-      lhs refine (ap (fun x => cocone_postcompose x t) 
-        (functor_colimit_commute m HQ1 HQ2)^).
+      lhs_V refine (ap (fun x => cocone_postcompose x t) 
+        (functor_colimit_commute m HQ1 HQ2)).
       lhs refine (cocone_precompose_postcompose m t HQ2).
       reflexivity.
     Defined.
@@ -247,7 +247,7 @@ Section FunctorialityColimit.
       = cocone_postcompose HQ1 (functor_colimit (diagram_comp n m) HQ1 HQ3).
   Proof.
     lhs refine (cocone_precompose_postcompose_comp m HQ1 HQ2 _).
-    lhs refine (ap _ (functor_colimit_commute n HQ2 HQ3)^).
+    lhs_V refine (ap _ (functor_colimit_commute n HQ2 HQ3)).
     lhs refine (cocone_precompose_comp n m _ HQ3).
     lhs refine (functor_colimit_commute (diagram_comp n m) _ _).
     reflexivity.

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -228,12 +228,12 @@ Section FunctorialityColimit.
     (m : DiagramMap D1 D2) {Q1 Q2 : Type} (HQ1 : IsColimit D1 Q1)
     (HQ2 : IsColimit D2 Q2) {T : Type} (t : Q2 -> T)
     : cocone_postcompose HQ1 (t o (functor_colimit m HQ1 HQ2))
-    = cocone_precompose m (cocone_postcompose HQ2 t).
+      = cocone_precompose m (cocone_postcompose HQ2 t).
     Proof.
       lhs nrapply cocone_postcompose_comp.
       lhs_V exact (ap (fun x => cocone_postcompose x t) 
         (functor_colimit_commute m HQ1 HQ2)).
-      snrapply cocone_precompose_postcompose.
+      nrapply cocone_precompose_postcompose.
     Defined.
 
   (** Functoriality of colimits *)
@@ -243,12 +243,12 @@ Section FunctorialityColimit.
     {Q1 Q2 Q3} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
     (HQ3 : IsColimit D3 Q3)
     : cocone_postcompose HQ1 ((functor_colimit n HQ2 HQ3) o (functor_colimit m HQ1 HQ2))
-    = cocone_postcompose HQ1 (functor_colimit (diagram_comp n m) HQ1 HQ3).
+      = cocone_postcompose HQ1 (functor_colimit (diagram_comp n m) HQ1 HQ3).
   Proof.
     lhs nrapply cocone_precompose_postcompose_comp.
     lhs_V nrapply (ap _ (functor_colimit_commute n HQ2 HQ3)).
     lhs nrapply cocone_precompose_comp.
-    snrapply functor_colimit_commute.
+    nrapply functor_colimit_commute.
   Defined.
 
   Definition functor_colimit_compose {D1 D2 D3 : Diagram G} 
@@ -256,8 +256,8 @@ Section FunctorialityColimit.
     {Q1 Q2 Q3} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
     (HQ3 : IsColimit D3 Q3)
     : (functor_colimit n HQ2 HQ3) o (functor_colimit m HQ1 HQ2)
-    = (functor_colimit (diagram_comp n m) HQ1 HQ3) 
-  := @equiv_inj _ _ 
+      = (functor_colimit (diagram_comp n m) HQ1 HQ3) 
+    := @equiv_inj _ _ 
       (cocone_postcompose HQ1) (iscolimit_unicocone HQ1 Q3) _ _ 
       (postcompose_functor_colimit_compose m n HQ1 HQ2 HQ3).
 

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -258,12 +258,10 @@ Section FunctorialityColimit.
     {Q1 Q2 Q3} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
     (HQ3 : IsColimit D3 Q3)
     : (functor_colimit n HQ2 HQ3) o (functor_colimit m HQ1 HQ2)
-      = (functor_colimit (diagram_comp n m) HQ1 HQ3).
-  Proof.
-    apply (@equiv_inj _ _ 
+      = (functor_colimit (diagram_comp n m) HQ1 HQ3) 
+  :=  @equiv_inj _ _ 
       (cocone_postcompose HQ1) (iscolimit_unicocone HQ1 Q3) _ _ 
-      (postcompose_functor_colimit_compose m n HQ1 HQ2 HQ3)).
-  Defined.
+      (postcompose_functor_colimit_compose m n HQ1 HQ2 HQ3).
 
   (** ** Colimits of equivalent diagrams *)
 

--- a/theories/PushoutPath/GraphQuotientPathInd.v
+++ b/theories/PushoutPath/GraphQuotientPathInd.v
@@ -4,7 +4,7 @@ Require Import Colimits.GraphQuotient.
 Require Import WildCat.
 
 (** This file proves the induction principle for path spaces of coequalizers. This follows the paper PATH SPACES OF HIGHER INDUCTIVE TYPES
-IN HOMOTOPY TYPE THEORY by Kraus and von Raumer. Their formalization can be found at https://gitlab.com/fplab/freealgstr. In the [FamilyCat] section we will define the categories C and D as described by this paper. C will be denoted as [ptd_family_with_relations], and D will be denoted as [ptd_family_graphquotient]. Since our final goal relies on the flatting lemma, we will assume univalence throughout the entire section. *)
+IN HOMOTOPY TYPE THEORY by Kraus and von Raumer. Their formalization can be found at https://gitlab.com/fplab/freealgstr. In the [FamilyCat] section we will define the categories C and D as described by this paper. C will be denoted as [ptd_family_with_relations], and D will be denoted as [ptd_family_graphquotient]. Since our final goal relies on the flatting lemma, we will currently assume univalence throughout the entire section. *)
 
 Section FamilyCat.
   Context `{Univalence} {A : Type} (a0 : A) (R : A -> A -> Type).
@@ -74,7 +74,7 @@ Section FamilyCat.
           nrapply (ap (f_ g c) (gamma_ f s k)).
   Defined.
 
-  (* I don't think these are the 2-cells that I want. At some point I need to use funext. *)
+  (* I don't think these are the 2-cells that I want. At some point I'm forced to use funext. Switching these cells out with some homtopies sounds smarter, but I'm not so sure how this is done, as I need transports as well. *)
   Instance is2graph_ptd_family_with_relations : Is2Graph ptd_family_with_relations.
   Proof.
     intros Kre Kre'.
@@ -152,7 +152,7 @@ Section FamilyCat.
 
   (** Since the 2-cells are defined to be paths, we trivially have morphism extensionality, and the 1-category is strong. *)
 
-  (* It would still be nice if this could be true with a better choice of paths. Since I'm assuming univalence, there should be a way to do this. *)
+  (* It would still be nice if this could be true with a better choice of paths. Since I'm assuming univalence, maybe a homotopy version of the above could work out niceky. *)
   Instance hasmorext_ptd_family_with_relations : HasMorExt ptd_family_with_relations.
   Proof.
     snrapply Build_HasMorExt.
@@ -161,7 +161,7 @@ Section FamilyCat.
     all: intros []; reflexivity.
   Defined.
 
-  (** [ptd_family_graphquotient] represents the wild category of pointed type families over the graph quotient of R. *)
+  (** [ptd_family_graphquotient] represents the wild category of pointed type families over the [GraphQuotient R]. *)
 
   Definition ptd_family_graphquotient : Type
     := {L : GraphQuotient R -> Type & L (gq a0)}.
@@ -209,7 +209,7 @@ Section FamilyCat.
         nrapply (epsilon_ g).
   Defined.
 
-  (* I don't think these are the 2-cells that I want. At some point I need to use Funext. *)
+  (* Likewise as above, these 2-cells does not seem to be the correct choice. We should only have the same problems of defnining homotopical versions for these 2-cells as before. *)
   Instance is2graph_ptd_family_graphquotient : Is2Graph ptd_family_graphquotient.
   Proof.
     intros Lp Lp'.
@@ -269,7 +269,7 @@ Section FamilyCat.
     - exact (idpath (gq a0)).
   Defined.
 
-  (* The choice of 2-cells makes this difficult to prove, as funext gets in the way. *)
+  (* The choice of 2-cells makes this very difficult to prove, as funext gets in the way. Maybe there is a simple solution that I just don't know of ¯\_(ツ)_/¯*)
   Definition isinitial_initLp : IsInitial initLp.
   Proof.
     intro Lp.

--- a/theories/PushoutPath/GraphQuotientPathInd.v
+++ b/theories/PushoutPath/GraphQuotientPathInd.v
@@ -4,12 +4,12 @@ Require Import Colimits.GraphQuotient.
 Require Import WildCat.
 
 (** This file proves the induction principle for path spaces of coequalizers. This follows the paper PATH SPACES OF HIGHER INDUCTIVE TYPES
-IN HOMOTOPY TYPE THEORY by Kraus and von Raumer. Their formalization can be found at https://gitlab.com/fplab/freealgstr. In the [FamilyCat] section we will define the categories C and D as described by this paper. C will be denoted as [ptd_family_with_relations], and D will be denoted as [ptd_family_graphquotient]. Since our final goal relies on the flatting lemma, we will currently assume univalence throughout the entire section. *)
+IN HOMOTOPY TYPE THEORY by Kraus and von Raumer. Their formalization can be found at https://gitlab.com/fplab/freealgstr. In the [FamilyCat] section we will define the categories [C] and [D] as described by this paper. [C] will be denoted [ptd_family_with_relations], and [D] will be denoted [ptd_family_graphquotient]. Since our final goal relies on the flattening lemma, we will currently assume univalence throughout the entire section. *)
 
 Section FamilyCat.
   Context `{Univalence} {A : Type} (a0 : A) (R : A -> A -> Type).
 
-  (** [ptd_family_with_relations] is represents the wild category of pointed type families that respects relations. That is, if there is a term [r : R b c], then there is an equivalence [K b <~> K c]. *)
+  (** [ptd_family_with_relations] represents the wild category of pointed type families that respect the relation. That is, if there is a term [r : R b c], then there is an equivalence [K b <~> K c]. *)
 
   Definition ptd_family_with_relations : Type 
     := {K : A -> Type & K a0 * forall b c : A, R b c -> K b <~> K c}.
@@ -26,7 +26,7 @@ Section FamilyCat.
   Definition e_ (Kre : ptd_family_with_relations) {b c : A} 
     : R b c -> (K_ Kre) b <~> (K_ Kre) c := snd (pr2 Kre) b c.
 
-  (** The arrows in this category is given by another triple. The first component is a collection of functions betwen the fibers of the type families. The second component is the assertion that this collection of functions respects the base point. The third component asserts that this collection is natural. *)
+  (** The arrows in this category are given by another triple. The first component is a collection of functions betwen the fibers of the type families. The second component is the assertion that this collection of functions respects the base point. The third component asserts that this collection is natural. *)
 
   Instance isgraph_ptd_family_with_relations : IsGraph ptd_family_with_relations.
   Proof.
@@ -38,7 +38,7 @@ Section FamilyCat.
         ((e_ Kre') s) o (f b) == (f c) o (e_ Kre) s}.
   Defined.
 
-  (** Accessors functions for the homs of [ptd_family_with_relations]. *)
+  (** Accessor functions for the homs of [ptd_family_with_relations]. *)
 
   (** first projection *)
   Definition f_ {Kre Kre' : ptd_family_with_relations} (f : Kre $-> Kre') (b : A)
@@ -152,7 +152,7 @@ Section FamilyCat.
 
   (** Since the 2-cells are defined to be paths, we trivially have morphism extensionality, and the 1-category is strong. *)
 
-  (* It would still be nice if this could be true with a better choice of paths. Since I'm assuming univalence, maybe a homotopy version of the above could work out niceky. *)
+  (* It would still be nice if this could be true with a better choice of paths. Since I'm assuming univalence, maybe a homotopy version of the above could work out nicely. *)
   Instance hasmorext_ptd_family_with_relations : HasMorExt ptd_family_with_relations.
   Proof.
     snrapply Build_HasMorExt.
@@ -174,7 +174,7 @@ Section FamilyCat.
   (** Second projection *)
   Definition p_ (Lp : ptd_family_graphquotient) : L_ Lp (gq a0) := pr2 Lp.
 
-  (** The arrows in this category is given by a touple. The first component is a collection of functions between the fibers of the type families. The second component is the assertion that this collection respects the basepoint. *)
+  (** The arrows in this category is given by a tuple. The first component is a collection of functions between the fibers of the type families. The second component is the assertion that this collection respects the basepoint. *)
 
   Instance isgraph_ptd_family_graphquotient : IsGraph ptd_family_graphquotient.
   Proof.

--- a/theories/PushoutPath/GraphQuotientPathInd.v
+++ b/theories/PushoutPath/GraphQuotientPathInd.v
@@ -1,0 +1,288 @@
+Require Import Types.
+Require Import Basics.
+Require Import Colimits.GraphQuotient.
+Require Import WildCat.
+
+(** This file proves the induction principle for path spaces of coequalizers. This follows the paper PATH SPACES OF HIGHER INDUCTIVE TYPES
+IN HOMOTOPY TYPE THEORY by Kraus and von Raumer. Their formalization can be found at https://gitlab.com/fplab/freealgstr. In the [FamilyCat] section we will define the categories C and D as described by this paper. C will be denoted as [ptd_family_with_relations], and D will be denoted as [ptd_family_graphquotient]. Since our final goal relies on the flatting lemma, we will assume univalence throughout the entire section. *)
+
+Section FamilyCat.
+  Context `{Univalence} {A : Type} (a0 : A) (R : A -> A -> Type).
+
+  (** [ptd_family_with_relations] is represents the wild category of pointed type families that respects relations. That is, if there is a term [r : R b c], then there is an equivalence [K b <~> K c]. *)
+
+  Definition ptd_family_with_relations : Type 
+    := {K : A -> Type & K a0 * forall b c : A, R b c -> K b <~> K c}.
+
+  (** Accessor functions for [ptd_family_with_relations]. *)
+
+  (** First projection *)
+  Definition K_ : ptd_family_with_relations -> A -> Type := pr1.
+
+  (** Second projection *)
+  Definition r_ (Kre : ptd_family_with_relations) : K_ Kre a0 := fst (pr2 Kre).
+
+  (** Third projection *)  
+  Definition e_ (Kre : ptd_family_with_relations) {b c : A} 
+    : R b c -> (K_ Kre) b <~> (K_ Kre) c := snd (pr2 Kre) b c.
+
+  (** The arrows in this category is given by another triple. The first component is a collection of functions betwen the fibers of the type families. The second component is the assertion that this collection of functions respects the base point. The third component asserts that this collection is natural. *)
+
+  Instance isgraph_ptd_family_with_relations : IsGraph ptd_family_with_relations.
+  Proof.
+    snrapply Build_IsGraph.
+    intros Kre Kre'.
+    exact {f : forall b : A, K_ Kre b -> K_ Kre' b 
+      & (f a0 (r_ Kre) = r_ Kre') 
+      * forall b c : A, forall s : R b c, 
+        ((e_ Kre') s) o (f b) == (f c) o (e_ Kre) s}.
+  Defined.
+
+  (** Accessors functions for the homs of [ptd_family_with_relations]. *)
+
+  (** first projection *)
+  Definition f_ {Kre Kre' : ptd_family_with_relations} (f : Kre $-> Kre') (b : A)
+    : K_ Kre b -> K_ Kre' b := pr1 f b.
+
+  (** Second projection *)
+  Definition d_ {Kre Kre' : ptd_family_with_relations} (f : Kre $-> Kre')
+    : f_ f a0 (r_ Kre) = r_ Kre' := fst (pr2 f).
+
+  (** Third projection *)
+  Definition gamma_ {Kre Kre' : ptd_family_with_relations} (f : Kre $-> Kre') 
+    {b c : A} (s : R b c) : (e_ Kre' s) o (f_ f b) == (f_ f c) o (e_ Kre s)
+    := snd (pr2 f) b c s.
+
+  (** [ptd_family_with_relations] defines a 1-category with morphism extensionality. *)
+
+  Instance is01cat_ptd_family_with_relations : Is01Cat ptd_family_with_relations.
+  Proof.
+    snrapply Build_Is01Cat.
+    - intro Kre.
+      srefine (_ ; _).
+      + intro a. exact idmap.
+      + srefine (_ , _).
+        * reflexivity.
+        * intros b c s k. reflexivity.
+    - intros Kre1 Kre2 Kre3 g f.
+      srefine (_ ; _).
+      + intro a. exact ((f_ g a) o (f_ f a)).
+      + srefine (_ , _).
+        * simpl. exact ((ap (f_ g a0) (d_ f)) @ d_ g).
+        * intros b c s k.
+          lhs nrapply (gamma_ g s).
+          nrapply (ap (f_ g c) (gamma_ f s k)).
+  Defined.
+
+  (* I don't think these are the 2-cells that I want. At some point I need to use funext. *)
+  Instance is2graph_ptd_family_with_relations : Is2Graph ptd_family_with_relations.
+  Proof.
+    intros Kre Kre'.
+    snrapply Build_IsGraph.
+    intros f g. exact (f = g).
+  Defined.
+
+  Instance is1cat_ptd_family_with_relations : Is1Cat ptd_family_with_relations.
+  Proof.
+    snrapply Build_Is1Cat'.
+    - intros Kre Kre'.
+      snrapply Build_Is01Cat.
+      + intros f. reflexivity.
+      + intros f g h p q. exact (q @ p).
+    - intros Kre Kre'.
+      snrapply Build_Is0Gpd.
+      + intros f g p. exact p^.
+    - intros Kre Kre' Kre'' f.
+      snrapply Build_Is0Functor.
+      + intros g h []. reflexivity.
+    - intros Kre Kre' Kre'' f.
+      snrapply Build_Is0Functor.
+      + intros g h []. reflexivity.
+    - intros Kre Kre' Kre'' Kre''' f g h.
+      snrapply path_sigma.
+      + reflexivity.
+      + unfold transport. 
+        snrapply path_prod.
+        * cbn.
+          lhs snrapply concat_p_pp.
+          apply (ap (fun x => x @ d_ h)).
+          lhs snrapply (ap_compose (f_ g a0) _ _ @@ 1).
+          snrapply (ap_pp _ _ _)^.
+        * cbn.
+          (* I don't like this *)
+          apply apD10^-1. intro b.
+          apply apD10^-1. intro c.
+          apply apD10^-1. intro s.
+          apply apD10^-1. intro k.
+          lhs_V nrapply concat_p_pp.
+          apply (ap (fun x => _ @ x)).
+          lhs nrapply (1 @@ ap_compose _ _ _).
+          nrapply (ap_pp _ _ _)^.
+    - intros Kre Kre' f.
+      snrapply path_sigma.
+      + reflexivity.
+      + unfold transport.
+        snrapply path_prod.
+        * cbn.
+          lhs nrapply concat_p1.
+          nrapply ap_idmap.
+        * cbn.
+          (* I don't like this *)
+          apply apD10^-1. intro b.
+          apply apD10^-1. intro c.
+          apply apD10^-1. intro s.
+          apply apD10^-1. intro k.
+          lhs nrapply concat_1p.
+          nrapply ap_idmap.
+    - intros Kre Kre' f.
+      snrapply path_sigma.
+      + reflexivity.
+      + unfold transport.
+        snrapply path_prod.
+        * cbn.
+          nrapply concat_1p.
+        * cbn.
+          (* I don't like this *)
+          apply apD10^-1. intro b.
+          apply apD10^-1. intro c.
+          apply apD10^-1. intro s.
+          apply apD10^-1. intro k.
+          nrapply concat_p1.
+  Defined.
+
+  (** Since the 2-cells are defined to be paths, we trivially have morphism extensionality, and the 1-category is strong. *)
+
+  (* It would still be nice if this could be true with a better choice of paths. Since I'm assuming univalence, there should be a way to do this. *)
+  Instance hasmorext_ptd_family_with_relations : HasMorExt ptd_family_with_relations.
+  Proof.
+    snrapply Build_HasMorExt.
+    intros Kre Kre' f g.
+    snrapply (Build_IsEquiv _ _ _ idmap).
+    all: intros []; reflexivity.
+  Defined.
+
+  (** [ptd_family_graphquotient] represents the wild category of pointed type families over the graph quotient of R. *)
+
+  Definition ptd_family_graphquotient : Type
+    := {L : GraphQuotient R -> Type & L (gq a0)}.
+
+  (** Accessor functions fpr [ptd_family_graphquotient]. *)
+
+  (** First projection *)
+  Definition L_ : ptd_family_graphquotient -> GraphQuotient R -> Type := pr1.
+
+  (** Second projection *)
+  Definition p_ (Lp : ptd_family_graphquotient) : L_ Lp (gq a0) := pr2 Lp.
+
+  (** The arrows in this category is given by a touple. The first component is a collection of functions between the fibers of the type families. The second component is the assertion that this collection respects the basepoint. *)
+
+  Instance isgraph_ptd_family_graphquotient : IsGraph ptd_family_graphquotient.
+  Proof.
+    snrapply Build_IsGraph.
+    intros Lp Lp'.
+    exact {g : forall x : GraphQuotient R, L_ Lp x -> L_ Lp' x 
+      & g _ (p_ Lp) = p_ Lp'}.
+  Defined.
+
+  (** Accessor functions for the homs of [ptd_family_graphquotient]. *)
+
+  (** First projection *)
+  Definition g_ {Lp Lp' : ptd_family_graphquotient} (f : Lp $-> Lp') (x : GraphQuotient R) 
+    : L_ Lp x -> L_ Lp' x := pr1 f x.
+
+  (** Second projection *)
+  Definition epsilon_ {Lp Lp' : ptd_family_graphquotient} (f : Lp $-> Lp') 
+    : g_ f _ (p_ Lp) = p_ Lp' := pr2 f.
+
+  (** [ptd_family_graphquotient] defines a 1-category with morphism extensionality. *)
+
+  Instance is01cat_ptd_family_graphquotient : Is01Cat ptd_family_graphquotient.
+  Proof.
+    snrapply Build_Is01Cat.
+    - intros Lp. srefine (_ ; _).
+      + intro x. exact idmap.
+      + reflexivity.
+    - intros Lp Lp' Lp'' g f. srefine (_ ; _).
+      + intro x. exact ((g_ g x) o (g_ f x)).
+      + cbn.
+        lhs nrapply (ap _ (epsilon_ f)).
+        nrapply (epsilon_ g).
+  Defined.
+
+  (* I don't think these are the 2-cells that I want. At some point I need to use Funext. *)
+  Instance is2graph_ptd_family_graphquotient : Is2Graph ptd_family_graphquotient.
+  Proof.
+    intros Lp Lp'.
+    snrapply Build_IsGraph.
+    intros f g. exact (f = g).
+  Defined.
+
+  Instance is1cat_ptd_family_graphquotient : Is1Cat ptd_family_graphquotient.
+  Proof.
+    snrapply Build_Is1Cat'.
+    - intros Lp Lp'.
+      snrapply Build_Is01Cat.
+      + intro p. reflexivity.
+      + intros f g h [] []. reflexivity.
+    - intros Lp Lp'.
+      snrapply Build_Is0Gpd.
+      intros f g []. reflexivity.
+    - intros Lp Lp' Lp'' f.
+      snrapply Build_Is0Functor.
+      intros g h []. reflexivity.
+    - intros Lp Lp' Lp'' f.
+      snrapply Build_Is0Functor.
+      intros g h []. reflexivity.
+    - intros Lp Lp' Lp'' Lp''' f g h.
+      snrapply path_sigma.
+      + reflexivity.
+      + cbn.
+        lhs nrapply concat_p_pp.
+        apply (ap (fun x => x @ epsilon_ h)).
+        lhs nrapply (ap_compose _ _ _ @@ 1).
+        nrapply (ap_pp _ _ _)^.
+    - intros Lp Lp' f.
+      snrapply path_sigma.
+      + reflexivity.
+      + cbn.
+        lhs nrapply concat_p1.
+        nrapply ap_idmap.
+    - intros Lp Lp' f.
+      snrapply path_sigma.
+      + reflexivity.
+      + cbn. nrapply concat_1p.
+  Defined.
+
+  Instance hasmorext_ptd_family_graphquotient : HasMorExt ptd_family_graphquotient.
+  Proof.
+    snrapply Build_HasMorExt.
+    intros Lp Lp' f g.
+    snrapply (Build_IsEquiv _ _ _ idmap).
+    all: intros []; reflexivity.
+  Defined.
+
+  (** The initial object of [ptd_family_graphquotient]. *)
+  Definition initLp : ptd_family_graphquotient.
+  Proof.
+    srefine (_ ; _).
+    - intro x. exact (gq a0 = x).
+    - exact (idpath (gq a0)).
+  Defined.
+
+  (* The choice of 2-cells makes this difficult to prove, as funext gets in the way. *)
+  Definition isinitial_initLp : IsInitial initLp.
+  Proof.
+    intro Lp.
+    srefine (_ ; _).
+    - srefine (_ ; _).
+      + intros x []. exact (p_ Lp).
+      + reflexivity.
+    - intro f.
+      snrapply path_sigma.
+      + cbn.
+        apply apD10^-1. intro x.
+        apply apD10^-1. intros []. exact (epsilon_ f)^.
+      + unfold transport. cbn.
+  Abort.
+
+End FamilyCat.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -34,16 +34,16 @@ Require Import Types.
 
 Definition seq_to_succ_seq (A : Sequence) : DiagramMap A (succ_seq A).
 Proof.
-    snrapply Build_DiagramMap.
-    - intros n a. exact a^+. 
-    - intros m n [] x. reflexivity.
+  snrapply Build_DiagramMap.
+  - intros n a. exact a^+. 
+  - intros m n [] x. reflexivity.
 Defined.
 
 (** Given a map of sequences we can define a map between 
     their succesor sequences. *)
 
 Definition succ_seq_map_seq_map {A B : Sequence} (f : DiagramMap A B) 
-    : DiagramMap (succ_seq A) (succ_seq B).
+  : DiagramMap (succ_seq A) (succ_seq B).
 Proof.
  snrapply Build_DiagramMap.
  - intros n a. exact (f (S n) a).
@@ -53,138 +53,138 @@ Defined.
 (** We show that the map induced by succ_seq_to_seq_map is an equivalence. *)
 
 Section Is_Equiv_colim_succ_seq_to_seq_map.
-    Context `{Funext} {A : Sequence}
-        {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
-        {transfinite_succ_A : Type} 
-        (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A).
+  Context `{Funext} {A : Sequence}
+    {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
+    {transfinite_succ_A : Type} 
+    (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A).
 
     (** This is a map [transfinite_A -> transfinite_succ_A] *)
 
-    Definition abs_colim_seq_to_abs_colim_succ_seq
-        : transfinite_A -> transfinite_succ_A 
-    := functor_colimit (seq_to_succ_seq A) col_A col_succ_A.
+  Definition abs_colim_seq_to_abs_colim_succ_seq
+    : transfinite_A -> transfinite_succ_A 
+  := functor_colimit (seq_to_succ_seq A) col_A col_succ_A.
 
     (** We make a cocone from [succ_seq A] to [transfinite_A] *)
 
-    Definition cocone_succ_seq_over_col 
-        : Cocone (succ_seq A) transfinite_A.
-    Proof.
-        srapply Build_Cocone.
-        - intros n a. exact (col_A (S n) a).
-        - intros m n [] a. exact (legs_comm col_A _ _ _ _).
-    Defined.
+  Definition cocone_succ_seq_over_col 
+    : Cocone (succ_seq A) transfinite_A.
+  Proof.
+    srapply Build_Cocone.
+    - intros n a. exact (col_A (S n) a).
+    - intros m n [] a. exact (legs_comm col_A _ _ _ _).
+  Defined.
 
-    (** Using the cocone above, 
-        we obtain a map [transfinite_succ_A -> transfinite_A] *)
+  (** Using the cocone above, 
+      we obtain a map [transfinite_succ_A -> transfinite_A] *)
 
-    Definition abs_colim_succ_seq_to_abs_colim_seq
-        : transfinite_succ_A -> transfinite_A := 
-        (cocone_postcompose_inv col_succ_A cocone_succ_seq_over_col).
+  Definition abs_colim_succ_seq_to_abs_colim_seq
+    : transfinite_succ_A -> transfinite_A 
+  := (cocone_postcompose_inv col_succ_A cocone_succ_seq_over_col).
 
-    (** Our goal is to show that these maps are quasi-inverses
-        of each other. *)
+  (** Our goal is to show that these maps are quasi-inverses
+      of each other. *)
+
+  (** We start with showing that [abs_colim_seq_to_abs_colim_succ_seq]
+      is a split-monomorphism. [cocone_succ_seq_over_col] defines 
+      essentially the same cocone as [col_A]. I.e. the following 
+      diagram is commutative:
     
-    (** We start with showing that [abs_colim_seq_to_abs_colim_succ_seq]
-        is a split-monomorphism. [cocone_succ_seq_over_col] defines 
-        essentially the same cocone as [col_A]. I.e. the following 
-        diagram is commutative:
-        
-                   A          succ_seq A
-                ______          ______
-               |      | =====>  \     |
-               |      |         /     |
-                ‾‾‾‾‾‾          ‾‾‾‾‾‾
-                     \  \     /  /
-                col_A \  \   /  / cocone_succ_seq_over_col
-                        colim A
+                  A          succ_seq A
+               ______          ______
+              |      | =====>  \     |
+              |      |         /     |
+               ‾‾‾‾‾‾          ‾‾‾‾‾‾
+                   \  \     /  /
+              col_A \  \   /  / cocone_succ_seq_over_col
+                      colim A
+
+  *)
+
+  Definition legs_comm_cocone_succ_seq_over_col_with_col 
+    (n : sequence_graph) 
+    : cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col n
+      == col_A n := (legs_comm (iscolimit_cocone col_A) _ _ _).
+
+  Definition cocone_succ_seq_over_col_is_ess_col 
+    : cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col
+    = iscolimit_cocone col_A.
+  Proof.
+    apply (path_cocone 
+      legs_comm_cocone_succ_seq_over_col_with_col).
+    intros m n [] a. 
+    unfold legs_comm_cocone_succ_seq_over_col_with_col.
+    simpl.
+    lhs refine 
+      (ap (fun x => x @ legs_comm col_A m (S m) 1 a) (concat_1p _)).
+    reflexivity.
+  Defined.
+
+  (** The cocone [col_A] indeces [idmap : transfinite_A -> transfinite_A]. *)
+
+  Definition col_legs_induces_idmap 
+    : cocone_postcompose_inv col_A col_A = idmap.
+  Proof.
+    apply (@equiv_inj _ _ (cocone_postcompose col_A)
+      (iscolimit_unicocone col_A transfinite_A) _ _).
+    lhs snrapply (eisretr (cocone_postcompose col_A)).
+    rhs snrapply (cocone_postcompose_identity col_A).
+    reflexivity.
+  Defined.
+
+  (** [cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col] 
+      induces the composite [abs_colim_succ_seq_to_abs_colim_seq
+      o abs_colim_seq_to_abs_colim_succ_seq] *)
+
+  Definition cocone_precompose_seq_to_succ_seq_cocone_succ_seq_over_col_induces_comp
+    : cocone_postcompose_inv col_A (cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col)
+    = abs_colim_succ_seq_to_abs_colim_seq
+    o abs_colim_seq_to_abs_colim_succ_seq. 
+  Proof.
+    apply (@equiv_inj _ _ (cocone_postcompose col_A)
+      (iscolimit_unicocone col_A transfinite_A) _ _).
+    rhs snrapply cocone_postcompose_comp.
+    unfold abs_colim_seq_to_abs_colim_succ_seq.
+    rhs snrapply (ap (fun x => cocone_postcompose x 
+      abs_colim_succ_seq_to_abs_colim_seq) 
+      (functor_colimit_commute _ _ _)^).
+    rhs snrapply cocone_precompose_postcompose.
+    unfold abs_colim_succ_seq_to_abs_colim_seq.
+    rhs snrapply (ap (fun x => cocone_precompose (seq_to_succ_seq A) x) 
+      (eisretr (cocone_postcompose col_succ_A) cocone_succ_seq_over_col)).
+    lhs snrapply (eisretr (cocone_postcompose col_A)).
+    reflexivity.
+  Defined.
+
+  Definition sec_abs_colim_seq_to_abs_succ_seq
+    : abs_colim_succ_seq_to_abs_colim_seq
+    o abs_colim_seq_to_abs_colim_succ_seq
+    = idmap.
+  Proof.
+    lhs snrapply cocone_precompose_seq_to_succ_seq_cocone_succ_seq_over_col_induces_comp^.
+    lhs snrapply (ap (fun x => cocone_postcompose_inv col_A x) 
+      cocone_succ_seq_over_col_is_ess_col).
+    exact (col_legs_induces_idmap).
+  Defined.
+
+  (** Hack while I think about this property *)
+
+    Definition ret_abs_colim_seq_to_abs_succ_seq
+      : abs_colim_seq_to_abs_colim_succ_seq 
+      o abs_colim_succ_seq_to_abs_colim_seq
+      = idmap.
+    Proof.
+    Admitted.
+
+  (** [abs_colim_seq_to_abs_colim_succ_seq] is an equivalence *)
     
-        *)
-
-    Definition legs_comm_cocone_succ_seq_over_col_with_col 
-        (n : sequence_graph) 
-        : cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col n
-         == col_A n := (legs_comm (iscolimit_cocone col_A) _ _ _).
-
-    Definition cocone_succ_seq_over_col_is_ess_col 
-        : cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col
-        = iscolimit_cocone col_A.
-    Proof.
-        apply (path_cocone 
-            legs_comm_cocone_succ_seq_over_col_with_col).
-        intros m n [] a. 
-        unfold legs_comm_cocone_succ_seq_over_col_with_col.
-        simpl.
-        lhs refine 
-            (ap (fun x => x @ legs_comm col_A m (S m) 1 a) (concat_1p _)).
-        reflexivity.
-    Defined.
-
-    (** The cocone [col_A] indeces [idmap : transfinite_A -> transfinite_A]. *)
-
-    Definition col_legs_induces_idmap 
-        : cocone_postcompose_inv col_A col_A = idmap.
-    Proof.
-        apply (@equiv_inj _ _ (cocone_postcompose col_A)
-            (iscolimit_unicocone col_A transfinite_A) _ _).
-        lhs snrapply (eisretr (cocone_postcompose col_A)).
-        rhs snrapply (cocone_postcompose_identity col_A).
-        reflexivity.
-    Defined.
-
-    (** [cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col] 
-        induces the composite [abs_colim_succ_seq_to_abs_colim_seq
-        o abs_colim_seq_to_abs_colim_succ_seq] *)
-
-    Definition cocone_precompose_seq_to_succ_seq_cocone_succ_seq_over_col_induces_comp
-        : cocone_postcompose_inv col_A (cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col)
-            = abs_colim_succ_seq_to_abs_colim_seq
-            o abs_colim_seq_to_abs_colim_succ_seq. 
-    Proof.
-        apply (@equiv_inj _ _ (cocone_postcompose col_A)
-            (iscolimit_unicocone col_A transfinite_A) _ _).
-        rhs snrapply cocone_postcompose_comp.
-        unfold abs_colim_seq_to_abs_colim_succ_seq.
-        rhs snrapply (ap (fun x => cocone_postcompose x 
-            abs_colim_succ_seq_to_abs_colim_seq) 
-            (functor_colimit_commute _ _ _)^).
-        rhs snrapply cocone_precompose_postcompose.
-        unfold abs_colim_succ_seq_to_abs_colim_seq.
-        rhs snrapply (ap (fun x => cocone_precompose (seq_to_succ_seq A) x) 
-            (eisretr (cocone_postcompose col_succ_A) cocone_succ_seq_over_col)).
-        lhs snrapply (eisretr (cocone_postcompose col_A)).
-        reflexivity.
-    Defined.
-
-    Definition sec_abs_colim_seq_to_abs_succ_seq
-        : abs_colim_succ_seq_to_abs_colim_seq
-            o abs_colim_seq_to_abs_colim_succ_seq
-            = idmap.
-    Proof.
-        lhs snrapply cocone_precompose_seq_to_succ_seq_cocone_succ_seq_over_col_induces_comp^.
-        lhs snrapply (ap (fun x => cocone_postcompose_inv col_A x) 
-            cocone_succ_seq_over_col_is_ess_col).
-        exact (col_legs_induces_idmap).
-    Defined.
-
-        (** Hack while I think about this property *)
-
-        Definition ret_abs_colim_seq_to_abs_succ_seq
-            : abs_colim_seq_to_abs_colim_succ_seq 
-                o abs_colim_succ_seq_to_abs_colim_seq
-                = idmap.
-        Proof.
-        Admitted.
-
-    (** [abs_colim_seq_to_abs_colim_succ_seq] is an equivalence *)
-    
-    Definition equiv_abs_colim_seq_to_abs_colim_succ_seq
-        : IsEquiv abs_colim_seq_to_abs_colim_succ_seq.
-    Proof.
-        snrapply isequiv_adjointify.
-        - exact abs_colim_succ_seq_to_abs_colim_seq.
-        - exact (apD10 ret_abs_colim_seq_to_abs_succ_seq).
-        - exact (apD10 sec_abs_colim_seq_to_abs_succ_seq).
-    Defined.
+  Definition equiv_abs_colim_seq_to_abs_colim_succ_seq
+    : IsEquiv abs_colim_seq_to_abs_colim_succ_seq.
+  Proof.
+    snrapply isequiv_adjointify.
+    - exact abs_colim_succ_seq_to_abs_colim_seq.
+    - exact (apD10 ret_abs_colim_seq_to_abs_succ_seq).
+    - exact (apD10 sec_abs_colim_seq_to_abs_succ_seq).
+  Defined.
 
 End Is_Equiv_colim_succ_seq_to_seq_map.
 
@@ -194,17 +194,17 @@ End Is_Equiv_colim_succ_seq_to_seq_map.
     We then expect colim A to be a retract of colim B as well. *)
 
 Section Intersplitting.
-    Context `{Funext} {A B : Sequence} 
-        {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
-        {transfinite_succ_A : Type} 
-        (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A)
-        {transfinite_B : Type} (col_B : IsColimit B transfinite_B)
-        (d : DiagramMap A B) 
-        (u : DiagramMap B (succ_seq A))
-        (comm_triangle : seq_to_succ_seq A = diagram_comp u d).
+  Context `{Funext} {A B : Sequence} 
+    {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
+    {transfinite_succ_A : Type} 
+    (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A)
+    {transfinite_B : Type} (col_B : IsColimit B transfinite_B)
+    (d : DiagramMap A B) 
+    (u : DiagramMap B (succ_seq A))
+    (comm_triangle : seq_to_succ_seq A = diagram_comp u d).
     
-    (** Given the data above, we show that the associated diagram in the
-        colimit is also commutative.
+  (** Given the data above, we show that the associated diagram in the
+      colimit is also commutative.
 
                   ≃
         col A_i -----> col A_i+1
@@ -214,31 +214,31 @@ Section Intersplitting.
                v     /
               col B_i
 
-        It follows that d is split-epi, and u is split-mono, as desired.
-    *)
+      It follows that d is split-epi, and u is split-mono, as desired.
+  *)
 
-    Definition colimit_comm_triangle : 
-        abs_colim_seq_to_abs_colim_succ_seq col_A col_succ_A 
-          = (functor_colimit u _ _) o (functor_colimit d _ _).
-    Proof.
-        rhs snrapply functoriality_functor_colimit.
-        rhs refine (ap (fun x => functor_colimit x col_A col_succ_A) 
-            comm_triangle^).
-        reflexivity.
-    Defined.
+  Definition colimit_comm_triangle : 
+    abs_colim_seq_to_abs_colim_succ_seq col_A col_succ_A 
+    = (functor_colimit u _ _) o (functor_colimit d _ _).
+  Proof.
+    rhs snrapply functoriality_functor_colimit.
+    rhs refine (ap (fun x => functor_colimit x col_A col_succ_A) 
+      comm_triangle^).
+    reflexivity.
+  Defined.
 
-    Definition isequiv_colim_composite
-        : IsEquiv ((functor_colimit u col_B col_succ_A) o (functor_colimit d col_A col_B)).
-    Proof.
-        apply (@isequiv_homotopic
-          transfinite_A
-          transfinite_succ_A
-          (abs_colim_seq_to_abs_colim_succ_seq col_A col_succ_A)
-          ((functor_colimit u _ _) o (functor_colimit d _ _))
-          (equiv_abs_colim_seq_to_abs_colim_succ_seq col_A col_succ_A)).
-        apply apD10.
-        exact colimit_comm_triangle.
-    Defined.
+  Definition isequiv_colim_composite
+    : IsEquiv ((functor_colimit u col_B col_succ_A) o (functor_colimit d col_A col_B)).
+  Proof.
+    apply (@isequiv_homotopic
+      transfinite_A
+      transfinite_succ_A
+      (abs_colim_seq_to_abs_colim_succ_seq col_A col_succ_A)
+      ((functor_colimit u _ _) o (functor_colimit d _ _))
+      (equiv_abs_colim_seq_to_abs_colim_succ_seq col_A col_succ_A)).
+    apply apD10.
+    exact colimit_comm_triangle.
+  Defined.
 
 End Intersplitting.
 
@@ -247,29 +247,29 @@ End Intersplitting.
     this diagram is an equivalence. *)
 
 Section Interleaving.
-    Context `{Funext} {A B : Sequence} 
-        {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
-        {transfinite_succ_A : Type} (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A)
-        {transfinite_B : Type} (col_B : IsColimit B transfinite_B)
-        {transfinite_succ_B : Type} (col_succ_B : IsColimit (succ_seq B) transfinite_succ_B)
-        (d : DiagramMap A B) 
-        (u : DiagramMap B (succ_seq A))
-        (tri1 : seq_to_succ_seq A = diagram_comp u d)
-        (tri2 : seq_to_succ_seq B = diagram_comp (succ_seq_map_seq_map d) u).
+  Context `{Funext} {A B : Sequence} 
+    {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
+    {transfinite_succ_A : Type} (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A)
+    {transfinite_B : Type} (col_B : IsColimit B transfinite_B)
+    {transfinite_succ_B : Type} (col_succ_B : IsColimit (succ_seq B) transfinite_succ_B)
+    (d : DiagramMap A B) 
+    (u : DiagramMap B (succ_seq A))
+    (tri1 : seq_to_succ_seq A = diagram_comp u d)
+    (tri2 : seq_to_succ_seq B = diagram_comp (succ_seq_map_seq_map d) u).
 
-    Definition isequiv_interleaved_colim_maps
-        : IsEquiv (functor_colimit d _ _) * IsEquiv (functor_colimit u _ _) * IsEquiv (functor_colimit (succ_seq_map_seq_map d) _ _).
-    Proof.
-        snrapply two_out_of_six.
-        - exact (isequiv_colim_composite col_A col_succ_A col_B d u tri1).
-        - exact (isequiv_colim_composite col_B col_succ_B col_succ_A u (succ_seq_map_seq_map d) tri2).
-    Defined.
+  Definition isequiv_interleaved_colim_maps
+    : IsEquiv (functor_colimit d _ _) * IsEquiv (functor_colimit u _ _) * IsEquiv (functor_colimit (succ_seq_map_seq_map d) _ _).
+  Proof.
+    snrapply two_out_of_six.
+    - exact (isequiv_colim_composite col_A col_succ_A col_B d u tri1).
+    - exact (isequiv_colim_composite col_B col_succ_B col_succ_A u (succ_seq_map_seq_map d) tri2).
+  Defined.
 
-    Definition equiv_interleaved_colim : transfinite_A <~> transfinite_B.
-    Proof.
-        snrapply Build_Equiv.
-        - exact (functor_colimit d col_A col_B).
-        - exact ((fst o fst) isequiv_interleaved_colim_maps).
-    Defined.
+  Definition equiv_interleaved_colim : transfinite_A <~> transfinite_B.
+  Proof.
+    snrapply Build_Equiv.
+    - exact (functor_colimit d col_A col_B).
+    - exact ((fst o fst) isequiv_interleaved_colim_maps).
+  Defined.
 
 End Interleaving.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -292,6 +292,10 @@ Section Intersplitting.
 
 End Intersplitting.
 
+(** Given families of maps `f n : A n -> B n` and `g : B n -> A (n + 1)` with homotopies
+showing that they form zigzags, construct the actual diagram maps and show that their
+composition is equal to the successor diagram map. *)
+
 Section Interme.
   Context `{Funext} {A B : Sequence}
     (f : forall (n : nat), A n -> B n)
@@ -299,6 +303,8 @@ Section Interme.
     (U : forall (n : nat), (fun (x : A n) => x^+) == (g n) o (f n))
     (L : forall (n : nat), (fun (x : B n) => x^+) == (f (S n)) o (g n)).
 
+  (** The map built from `f`. Note that [zigzag_glue_map_tri] depends heavily on the exact 
+  homotopy used here. *)
   Definition zigzag_glue_map : DiagramMap A B.
   Proof.
     snrapply Build_DiagramMap.
@@ -309,6 +315,7 @@ Section Interme.
       exact (U n x)^.
   Defined.
 
+  (** The map built from `g`. *)
   Definition zigzag_glue_map_inv : DiagramMap B (succ_seq A).
   Proof.
     snrapply Build_DiagramMap.
@@ -321,7 +328,8 @@ Section Interme.
 
   Local Open Scope path_scope.
 
-  Definition zigzag_glue_map_tr : (diagram_comp zigzag_glue_map_inv zigzag_glue_map) = seq_to_succ_seq A.
+  (** Show that the composition of the two maps is the successor map. *)
+  Definition zigzag_glue_map_tri : (diagram_comp zigzag_glue_map_inv zigzag_glue_map) = seq_to_succ_seq A.
   Proof.
     snrapply path_DiagramMap.
     - intros n x.
@@ -370,7 +378,7 @@ Section Interme.
 End Interme.
 
 (** Assuming that there are [A, B : Sequence] that fits in an interleaving diagram,
-    their colimits are isomorphic. We proceed by using th 2-out-of-6 property.  *)
+    their colimits are isomorphic. We proceed by using the 2-out-of-6 property.  *)
 
 Section Interleaving.
   Context `{Funext} {A B : Sequence} 
@@ -384,12 +392,15 @@ Section Interleaving.
   Let d := zigzag_glue_map f g U L.
 
   Let u := zigzag_glue_map_inv f g U L.
+  
+  (* We need two equalities: [seq_to_succ_seq A = d o u] and 
+  [seq_to_succ_seq B = (succ_seq_map_seq_map d) o u. *)
 
-  (** The first equality needed is exactly what we came up with in the previous section. *)
+  (* The first equality needed is exactly what we came up with in the previous section. *)
   Let tri1 : seq_to_succ_seq A = diagram_comp u d
-    := (zigzag_glue_map_tr f g U L)^.
+    := (zigzag_glue_map_tri f g U L)^.
 
-  (** The second one requires some massaging: applying `zigzag_glue_map_tr` to the shifted 
+  (* The second one requires some massaging: applying [zigzag_glue_map_tr] to the shifted 
   functions doesn't exactly give us `(succ_seq_map_seq_map d)`, but we can find an equality
   between them. *)
   (* TODO: This probably shouldn't be necessary. *)
@@ -401,7 +412,7 @@ Section Interleaving.
     pose (U' := L);
     pose (L' := (fun n => U (S n)));
     (* Coq can't guess `succ_seq A` here *)
-    pose (attempt := (@zigzag_glue_map_tr _ B (succ_seq A) f' g' U' L')).
+    pose (attempt := (@zigzag_glue_map_tri _ B (succ_seq A) f' g' U' L')).
     assert (eq : (succ_seq_map_seq_map d) = (@zigzag_glue_map_inv B (succ_seq A) f' g' U' L')).
     - snrapply path_DiagramMap.
       + reflexivity.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -12,7 +12,7 @@ Require Import Colimits.Sequential.
 Require Import Diagram.
 Require Import Types.
 
-(** Suppose we have sequences [A_i] and [B_i]. An interleaving from [A_i] to [B_i] consists of two natural transformations d : A_i => B_i (d for down) and u : B_i => A_i+1 (u for up), such that the composites (u o d) and (d o i) correspond to the morphisms in the diagram itself. In other words, the following diagram is commutative:
+(** Suppose we have sequences [A_i] and [B_i]. An interleaving from [A_i] to [B_i] consists of two natural transformations [d : A_i => B_i] ([d] for down) and [u : B_i => A_i+1] ([u] for up), such that the following diagram is commutative:
 
 <<
     A_0 -------> A_1 ------> A_2 ------>
@@ -23,8 +23,9 @@ Require Import Types.
            B_0 ------> B_1 ------->
 >>
 
-Given the setup above, we want to say that the colimit of the upper lower sequences are the same. From a sequence A, we can produce a diagram map from [A] to [succ_seq A]. It's the map that applies the arrow in the sequence to every element. *)
+Given the setup above, we want to say that the colimit of the upper and lower sequences are the same. *)
 
+(** From a sequence [A], we can produce a diagram map from [A] to [succ_seq A]. It's the map that applies the arrow in the sequence to every element. *)
 Definition seq_to_succ_seq (A : Sequence) : DiagramMap A (succ_seq A).
 Proof.
   snrapply Build_DiagramMap.
@@ -32,9 +33,7 @@ Proof.
   - intros m n [] x. reflexivity.
 Defined.
 
-(** Given a map of sequences we can define a map between 
-    their succesor sequences. *)
-
+(** Given a map of sequences we can define a map between their succesor sequences. *)
 Definition succ_seq_map_seq_map {A B : Sequence} (f : DiagramMap A B) 
   : DiagramMap (succ_seq A) (succ_seq B).
 Proof.
@@ -43,8 +42,7 @@ Proof.
   - intros m n []. exact (DiagramMap_comm f _).
 Defined.
 
-(** A cocone over a sequence defines a cocone over the successor sequence *)
-
+(** A cocone over a sequence defines a cocone over the successor sequence. *)
 Definition succ_seq_cocone_seq_cocone {A : Sequence} (T : Type) (C : Cocone A T)
   : Cocone (succ_seq A) T.
 Proof.
@@ -53,8 +51,7 @@ Proof.
   - intros m n []. rapply (legs_comm C).
 Defined.
 
-(** [cocone_precompose (seq_to_succ_seq A)] is an equivalence *)
-
+(** [cocone_precompose (seq_to_succ_seq A)] is an equivalence. *)
 Definition isequiv_cocone_precompose_seq_to_succ_seq
   `{Funext} {A : Sequence} {X : Type} 
   : IsEquiv (cocone_precompose (seq_to_succ_seq A) (X:=X)).
@@ -74,7 +71,6 @@ Proof.
 Defined.
 
 (** The cocone [colim_A] induces [idmap : A_w -> A_w]. *)
-
 Definition col_legs_induces_idmap `{Funext} {A : Sequence}
   {A_w} (colim_A : IsColimit A A_w) 
   : cocone_postcompose_inv colim_A colim_A = idmap.
@@ -87,12 +83,12 @@ Defined.
 
 (** We show that the map induced by [succ_seq_to_seq] is an equivalence. *)
 
+(* jdc: Let's use CamelCase names for Sections.  They can also be less descriptive, since they are never looked up. *)
 Section Is_Equiv_colim_succ_seq_to_seq_map.
   Context `{Funext} {A : Sequence}
     {A_w : Type} (colim_A : IsColimit A A_w).
 
-  (** The legs of [colim_A] induces a cocone from [succ_seq A] over [A_w] *)
-
+  (** The legs of [colim_A] induces a cocone from [succ_seq A] over [A_w]. *)
   Definition cocone_succ_seq_over_col 
     : Cocone (succ_seq A) A_w
     := succ_seq_cocone_seq_cocone A_w colim_A.
@@ -127,7 +123,7 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
     simpl. exact (concat_1p _ @@ 1).
   Defined.
 
-  (* The cocone of [succ_seq A] over colim A is universal *)
+  (* The cocone of [succ_seq A] over colim A is universal *) (* jdc: I'll let you add periods and remove blank lines throughout. *)
 
   Instance iscolimit_succ_seq_A_over_A_w : IsColimit (succ_seq A) A_w.
   Proof.
@@ -350,6 +346,7 @@ Section Interme.
   Defined.
 End Interme.
 
+(* jdc: No line breaks in comments *)
 (** Assuming that there are [A, B : Sequence] that fits in an interleaving diagram,
     their colimits are isomorphic. We proceed by using the 2-out-of-6 property.  *)
 
@@ -371,13 +368,13 @@ Section Interleaving.
 
   (* The first equality needed is exactly what we came up with in the previous section. *)
   Let tri1 : seq_to_succ_seq A = diagram_comp u d
-   := (zigzag_glue_map_tri f g U L)^.
+    := (zigzag_glue_map_tri f g U L)^.
 
   (* The second one requires some massaging: applying [zigzag_glue_map_tr] to the shifted 
   functions doesn't exactly give us [succ_seq_map_seq_map d], but we can find an equality
   between them. *)
   (* TODO: This probably shouldn't be necessary. *)
-  Let tri2 : seq_to_succ_seq B = diagram_comp (succ_seq_map_seq_map d) u.
+  Definition tri2 : seq_to_succ_seq B = diagram_comp (succ_seq_map_seq_map d) u.
   Proof.
     symmetry.
     pose (f':=g);

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -227,6 +227,19 @@ Section Intersplitting.
         reflexivity.
     Defined.
 
+    Definition isequiv_colim_composite
+        : IsEquiv ((functor_colimit u col_B col_succ_A) o (functor_colimit d col_A col_B)).
+    Proof.
+        apply (@isequiv_homotopic
+          transfinite_A
+          transfinite_succ_A
+          (abs_colim_seq_to_abs_colim_succ_seq col_A col_succ_A)
+          ((functor_colimit u _ _) o (functor_colimit d _ _))
+          (equiv_abs_colim_seq_to_abs_colim_succ_seq col_A col_succ_A)).
+        apply apD10.
+        exact colimit_comm_triangle.
+    Defined.
+
 End Intersplitting.
 
 (** Now we will assume that every triangle is commutative.
@@ -234,12 +247,29 @@ End Intersplitting.
     this diagram is an equivalence. *)
 
 Section Interleaving.
-    Context {A B : Sequence} 
-        {transfiniteA : Type} (colA : IsColimit A transfiniteA)
-        {transfiniteB : Type} (colB : IsColimit B transfiniteB)
+    Context `{Funext} {A B : Sequence} 
+        {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
+        {transfinite_succ_A : Type} (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A)
+        {transfinite_B : Type} (col_B : IsColimit B transfinite_B)
+        {transfinite_succ_B : Type} (col_succ_B : IsColimit (succ_seq B) transfinite_succ_B)
         (d : DiagramMap A B) 
         (u : DiagramMap B (succ_seq A))
         (tri1 : seq_to_succ_seq A = diagram_comp u d)
         (tri2 : seq_to_succ_seq B = diagram_comp (succ_seq_map_seq_map d) u).
+
+    Definition isequiv_interleaved_colim_maps
+        : IsEquiv (functor_colimit d _ _) * IsEquiv (functor_colimit u _ _) * IsEquiv (functor_colimit (succ_seq_map_seq_map d) _ _).
+    Proof.
+        snrapply two_out_of_six.
+        - exact (isequiv_colim_composite col_A col_succ_A col_B d u tri1).
+        - exact (isequiv_colim_composite col_B col_succ_B col_succ_A u (succ_seq_map_seq_map d) tri2).
+    Defined.
+
+    Definition equiv_interleaved_colim : transfinite_A <~> transfinite_B.
+    Proof.
+        snrapply Build_Equiv.
+        - exact (functor_colimit d col_A col_B).
+        - exact ((fst o fst) isequiv_interleaved_colim_maps).
+    Defined.
 
 End Interleaving.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -108,7 +108,7 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
 
   Definition cocone_succ_seq_over_col_is_ess_col 
     : cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col
-    = iscolimit_cocone col_A.
+      = iscolimit_cocone col_A.
   Proof.
     apply (path_cocone 
       legs_comm_cocone_succ_seq_over_col_with_col).
@@ -137,17 +137,18 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
       o abs_colim_seq_to_abs_colim_succ_seq] *)
 
   Definition cocone_precompose_seq_to_succ_seq_cocone_succ_seq_over_col_induces_comp
-    : cocone_postcompose_inv col_A (cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col)
-    = abs_colim_succ_seq_to_abs_colim_seq
-    o abs_colim_seq_to_abs_colim_succ_seq. 
+    : cocone_postcompose_inv col_A 
+      (cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col)
+      = abs_colim_succ_seq_to_abs_colim_seq
+      o abs_colim_seq_to_abs_colim_succ_seq. 
   Proof.
     apply (@equiv_inj _ _ (cocone_postcompose col_A)
       (iscolimit_unicocone col_A transfinite_A) _ _).
     rhs snrapply cocone_postcompose_comp.
     unfold abs_colim_seq_to_abs_colim_succ_seq.
-    rhs snrapply (ap (fun x => cocone_postcompose x 
+    rhs_V snrapply (ap (fun x => cocone_postcompose x 
       abs_colim_succ_seq_to_abs_colim_seq) 
-      (functor_colimit_commute _ _ _)^).
+      (functor_colimit_commute _ _ _)).
     rhs snrapply cocone_precompose_postcompose.
     unfold abs_colim_succ_seq_to_abs_colim_seq.
     rhs snrapply (ap (fun x => cocone_precompose (seq_to_succ_seq A) x) 
@@ -161,7 +162,8 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
     o abs_colim_seq_to_abs_colim_succ_seq
     = idmap.
   Proof.
-    lhs snrapply cocone_precompose_seq_to_succ_seq_cocone_succ_seq_over_col_induces_comp^.
+    lhs_V snrapply 
+      cocone_precompose_seq_to_succ_seq_cocone_succ_seq_over_col_induces_comp.
     lhs snrapply (ap (fun x => cocone_postcompose_inv col_A x) 
       cocone_succ_seq_over_col_is_ess_col).
     exact (col_legs_induces_idmap).
@@ -222,13 +224,14 @@ Section Intersplitting.
     = (functor_colimit u _ _) o (functor_colimit d _ _).
   Proof.
     rhs snrapply functor_colimit_compose.
-    rhs refine (ap (fun x => functor_colimit x col_A col_succ_A) 
-      comm_triangle^).
+    rhs_V refine (ap (fun x => functor_colimit x col_A col_succ_A) 
+      comm_triangle).
     reflexivity.
   Defined.
 
   Definition isequiv_colim_composite
-    : IsEquiv ((functor_colimit u col_B col_succ_A) o (functor_colimit d col_A col_B)).
+    : IsEquiv ((functor_colimit u col_B col_succ_A) 
+      o (functor_colimit d col_A col_B)).
   Proof.
     apply (@isequiv_homotopic
       transfinite_A
@@ -249,9 +252,11 @@ End Intersplitting.
 Section Interleaving.
   Context `{Funext} {A B : Sequence} 
     {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
-    {transfinite_succ_A : Type} (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A)
+    {transfinite_succ_A : Type} (col_succ_A : IsColimit (succ_seq A) 
+      transfinite_succ_A)
     {transfinite_B : Type} (col_B : IsColimit B transfinite_B)
-    {transfinite_succ_B : Type} (col_succ_B : IsColimit (succ_seq B) transfinite_succ_B)
+    {transfinite_succ_B : Type} (col_succ_B : IsColimit (succ_seq B) 
+      transfinite_succ_B)
     (d : DiagramMap A B) 
     (u : DiagramMap B (succ_seq A))
     (tri1 : seq_to_succ_seq A = diagram_comp u d)
@@ -262,7 +267,8 @@ Section Interleaving.
   Proof.
     snrapply two_out_of_six.
     - exact (isequiv_colim_composite col_A col_succ_A col_B d u tri1).
-    - exact (isequiv_colim_composite col_B col_succ_B col_succ_A u (succ_seq_map_seq_map d) tri2).
+    - exact (isequiv_colim_composite col_B col_succ_B col_succ_A u 
+      (succ_seq_map_seq_map d) tri2).
   Defined.
 
   Definition equiv_interleaved_colim : transfinite_A <~> transfinite_B.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -221,7 +221,7 @@ Section Intersplitting.
     abs_colim_seq_to_abs_colim_succ_seq col_A col_succ_A 
     = (functor_colimit u _ _) o (functor_colimit d _ _).
   Proof.
-    rhs snrapply functoriality_functor_colimit.
+    rhs snrapply functor_colimit_compose.
     rhs refine (ap (fun x => functor_colimit x col_A col_succ_A) 
       comm_triangle^).
     reflexivity.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -50,7 +50,7 @@ Proof.
  - intros m n [] a. exact (DiagramMap_comm f _ a).
 Defined.
 
-(** We show that the map induced by succ_seq_to_seq_map is an equivalence. *)
+(** We show that the map induced by [succ_seq_to_seq] is an equivalence. *)
 
 Section Is_Equiv_colim_succ_seq_to_seq_map.
   Context `{Funext} {A : Sequence}
@@ -58,13 +58,15 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
     {transfinite_succ_A : Type} 
     (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A).
 
-    (** This is a map [transfinite_A -> transfinite_succ_A] *)
+  (** We take the colimit of [seq_to_succ_seq]
+    and obtain a map [transfinite_A -> transfinite_succ_A] *)
 
   Definition abs_colim_seq_to_abs_colim_succ_seq
     : transfinite_A -> transfinite_succ_A 
   := functor_colimit (seq_to_succ_seq A) col_A col_succ_A.
 
-    (** We make a cocone from [succ_seq A] to [transfinite_A] *)
+  (** The legs of [col_A] induces a cocone from [succ_seq A] 
+    over [transfinite_A] *)
 
   Definition cocone_succ_seq_over_col 
     : Cocone (succ_seq A) transfinite_A.
@@ -74,8 +76,7 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
     - intros m n [] a. exact (legs_comm col_A _ _ _ _).
   Defined.
 
-  (** Using the cocone above, 
-      we obtain a map [transfinite_succ_A -> transfinite_A] *)
+  (** The cocone above induces a map [transfinite_succ_A -> transfinite_A] *)
 
   Definition abs_colim_succ_seq_to_abs_colim_seq
     : transfinite_succ_A -> transfinite_A 
@@ -84,9 +85,9 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
   (** Our goal is to show that these maps are quasi-inverses
       of each other. *)
 
-  (** We start with showing that [abs_colim_seq_to_abs_colim_succ_seq]
-      is a split-monomorphism. [cocone_succ_seq_over_col] defines 
-      essentially the same cocone as [col_A]. I.e. the following 
+  (** We start by showing that [abs_colim_seq_to_abs_colim_succ_seq]
+      is a split-monomorphism. Observe that [cocone_succ_seq_over_col]
+      essentially defines the same cocone as [col_A]. I.e. the following 
       diagram is commutative:
     
                   A          succ_seq A
@@ -119,7 +120,7 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
     reflexivity.
   Defined.
 
-  (** The cocone [col_A] indeces [idmap : transfinite_A -> transfinite_A]. *)
+  (** The cocone [col_A] induces [idmap : transfinite_A -> transfinite_A]. *)
 
   Definition col_legs_induces_idmap 
     : cocone_postcompose_inv col_A col_A = idmap.
@@ -190,8 +191,7 @@ End Is_Equiv_colim_succ_seq_to_seq_map.
 
 (** Intersplitting is a pun of interleaving and splitting. 
     We will at first only assume that every other triangle
-    is commutative. Intuitively, one may think of A as a retract of B. 
-    We then expect colim A to be a retract of colim B as well. *)
+    is commutative. In this case, colim A is a retract of colim B. *)
 
 Section Intersplitting.
   Context `{Funext} {A B : Sequence} 

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -239,7 +239,7 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
 
 End Is_Equiv_colim_succ_seq_to_seq_map.
 
-(** Intersplitting is a pun of interleaving and splitting. 
+(** Intersplitting is a portmanteau of interleaving and splitting. 
     We will at first only assume that every other triangle
     is commutative. In this case, colim A is a retract of colim B. *)
 
@@ -299,7 +299,7 @@ Section Interme.
     (U : forall (n : nat), (fun (x : A n) => x^+) == (g n) o (f n))
     (L : forall (n : nat), (fun (x : B n) => x^+) == (f (S n)) o (g n)).
 
-  Definition zigzag_map : DiagramMap A B.
+  Definition zigzag_glue_map : DiagramMap A B.
   Proof.
     snrapply Build_DiagramMap.
     - exact f.
@@ -309,7 +309,7 @@ Section Interme.
       exact (U n x)^.
   Defined.
 
-  Definition zigzag_map_inv : DiagramMap B (succ_seq A).
+  Definition zigzag_glue_map_inv : DiagramMap B (succ_seq A).
   Proof.
     snrapply Build_DiagramMap.
     - exact g.
@@ -321,7 +321,7 @@ Section Interme.
 
   Local Open Scope path_scope.
 
-  Definition zigzag_map_tr : (diagram_comp zigzag_map_inv zigzag_map) = seq_to_succ_seq A.
+  Definition zigzag_glue_map_tr : (diagram_comp zigzag_glue_map_inv zigzag_glue_map) = seq_to_succ_seq A.
   Proof.
     snrapply path_DiagramMap.
     - intros n x.
@@ -331,19 +331,41 @@ Section Interme.
       intros n m y x; destruct y.
       simpl.
       unfold CommutativeSquares.comm_square_comp.
+      (* We need to show, stripping brackets:
+      1)   U n.+1 (g n (f n x))
+      2) @ ap (g n.+1) (L n (f n x))^) 
+      3) @ ap (g n.+1) (L n (f n x) @ ap (f n.+1) (U n x)^)
+      4) @ (U n.+1 x ^+)^ 
+          = 
+      5)  ap (fun a : A n.+1%nat => a ^+) (U n x)^ 
+      6) @ 1
+       *)
+      (* Bring the concatenation out of `ap` in 3) *)
       rewrite (ap_pp (g n.+1) (L n (f n x)) (ap (f n.+1) (U n x)^)).
+      (* Bring the inverse out of `ap` in 1) *)
       rewrite (ap_V _ (L n (f n x))).
+      (* Remove reflexivity 6) *)
       rhs apply (concat_p1 (ap (fun a => a ^+) (U n x)^)).
+      (* Change associativity of 1 2 3 *)
       rewrite (concat_pp_p (U n.+1 _) ((ap (g n.+1) _)^) _).
+      (* Change associativity of 2 3 3.5 *)
       rewrite (concat_p_pp ((ap _ _)^) (ap _ _) _).
+      (* 2 and 3 are inverse *)
       rewrite (concat_Vp _).
+      (* Remove the reflexivity *)
       rewrite (concat_1p _).
+      (* Add (U n.+1 x ^* ) on the right to both sides *)
       apply (cancelR _ _ ((U n.+1 x ^+))).
+      (* Change associativity on the left... *)
       lhs refine (concat_pp_p _ _ _).
+      (* ...and cancel 4 with the newly-added path *)
       rewrite (concat_Vp _).
+      (* Remove the residual 1 *)
       rewrite (concat_p1 _).
+      (* `ap` of `ap` is `ap` of composition of functions *)
       rewrite (ap_compose (f n.+1) (g n.+1) _)^.
-      refine (concat_Ap _ _)^.
+      (* Finish by naturality of `ap` *)
+      exact (concat_Ap _ _)^.
   Defined.
 End Interme.
 
@@ -354,10 +376,42 @@ Section Interleaving.
   Context `{Funext} {A B : Sequence} 
     {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
     {transfinite_B : Type} (col_B : IsColimit B transfinite_B)
-    (d : DiagramMap A B) 
-    (u : DiagramMap B (succ_seq A))
-    (tri1 : seq_to_succ_seq A = diagram_comp u d)
-    (tri2 : seq_to_succ_seq B = diagram_comp (succ_seq_map_seq_map d) u).
+    (f : forall (n : nat), A n -> B n)
+    (g : forall (n : nat), B n -> A (S n))
+    (U : forall (n : nat), (fun (x : A n) => x^+) == (g n) o (f n))
+    (L : forall (n : nat), (fun (x : B n) => x^+) == (f (S n)) o (g n)).
+
+  Let d := zigzag_glue_map f g U L.
+
+  Let u := zigzag_glue_map_inv f g U L.
+
+  (** The first equality needed is exactly what we came up with in the previous section. *)
+  Let tri1 : seq_to_succ_seq A = diagram_comp u d
+    := (zigzag_glue_map_tr f g U L)^.
+
+  (** The second one requires some massaging: applying `zigzag_glue_map_tr` to the shifted 
+  functions doesn't exactly give us `(succ_seq_map_seq_map d)`, but we can find an equality
+  between them. *)
+  (* TODO: This probably shouldn't be necessary. *)
+  Let tri2 : seq_to_succ_seq B = diagram_comp (succ_seq_map_seq_map d) u.
+  Proof.
+    symmetry.
+    pose (f' := g);
+    pose (g' := (fun n => f (S n)));
+    pose (U' := L);
+    pose (L' := (fun n => U (S n)));
+    (* Coq can't guess `succ_seq A` here *)
+    pose (attempt := (@zigzag_glue_map_tr _ B (succ_seq A) f' g' U' L')).
+    assert (eq : (succ_seq_map_seq_map d) = (@zigzag_glue_map_inv B (succ_seq A) f' g' U' L')).
+    - snrapply path_DiagramMap.
+      + reflexivity.
+      + intros n m y x; destruct y. 
+        simpl.
+        rewrite (concat_1p _).
+        rewrite (concat_p1 _).
+        reflexivity.
+    - exact (transport (fun x => diagram_comp x u = seq_to_succ_seq B) eq^ attempt).
+  Defined.
 
   Definition isequiv_interleaved_colim_maps
     : IsEquiv (functor_colimit d _ _) * IsEquiv (functor_colimit u _ (col_succ col_A)) * IsEquiv (functor_colimit (succ_seq_map_seq_map d) (col_succ col_A) (col_succ col_B)).
@@ -374,5 +428,4 @@ Section Interleaving.
     - exact (functor_colimit d col_A col_B).
     - exact ((fst o fst) isequiv_interleaved_colim_maps).
   Defined.
-
 End Interleaving.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -325,15 +325,7 @@ Section Interme.
       intros n m [] x.
       simpl.
       unfold CommutativeSquares.comm_square_comp.
-      (* We need to show, stripping brackets:
-      1)   U n.+1 (g n (f n x))
-      2) @ ap (g n.+1) (L n (f n x))^) 
-      3) @ ap (g n.+1) (L n (f n x) @ ap (f n.+1) (U n x)^)
-      4) @ (U n.+1 x ^+)^ 
-          = 
-      5)  ap (fun a : A n.+1%nat => a ^+) (U n x)^ 
-      6) @ 1
-       *)
+      Local Open Scope long_path_scope.
       (* Bring the concatenation out of `ap` in 3) *)
       lhs nrapply (1 @@ ap_pp (g n.+1) (L n (f n x)) (ap (f n.+1) (U n x)^) @@ 1).
       (* Bring the inverse out of `ap` in 1) *)

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -254,7 +254,7 @@ Section Intersplitting.
   (** Given the data above, we show that the associated diagram in the
       colimit is also commutative.
 
-                  ≃
+                  id
         col A_i -----> col A_i+1
             \           ^
              \         /
@@ -282,9 +282,7 @@ Section Intersplitting.
     : IsEquiv ((functor_colimit u col_B (col_succ col_A)) 
       o (functor_colimit d col_A col_B)).
   Proof.
-    apply (@isequiv_homotopic
-      transfinite_A
-      transfinite_A
+    apply (@isequiv_homotopic transfinite_A _
       (abstr_colim_seq_to_abstr_colim_succ_seq col_A)
       ((functor_colimit u _ _) o (functor_colimit d _ _))
       (equiv_abstr_colim_seq_to_abstr_colim_succ_seq col_A)).
@@ -294,9 +292,8 @@ Section Intersplitting.
 
 End Intersplitting.
 
-(** Now we will assume that every triangle is commutative.
-    By the 2-out-of-6 property, it follows that every map in
-    this diagram is an equivalence. *)
+(** Assuming that there are [A, B : Sequence] that fits in an interleaving diagram,
+    their colimits are isomorphic. We proceed by using th 2-out-of-6 property.  *)
 
 Section Interleaving.
   Context `{Funext} {A B : Sequence} 

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -283,9 +283,7 @@ Section Intersplitting.
 
 End Intersplitting.
 
-(** Given families of maps `f n : A n -> B n` and `g : B n -> A (n + 1)` with homotopies
-showing that they form zigzags, construct the actual diagram maps and show that their
-composition is equal to the successor diagram map. *)
+(** Given families of maps `f n : A n -> B n` and `g : B n -> A (n + 1)` with homotopies showing that they form zigzags, construct the actual diagram maps and show that their composition is equal to the successor diagram map. *)
 
 Section Interme.
   Context `{Funext} {A B : Sequence}
@@ -294,13 +292,12 @@ Section Interme.
     (U : forall (n : nat), (fun (x : A n) => x^+) == (g n) o (f n))
     (L : forall (n : nat), (fun (x : B n) => x^+) == (f (S n)) o (g n)).
 
-  (** The map built from `f`. Note that [zigzag_glue_map_tri] depends heavily on the exact 
-  homotopy used here. *)
+  (** The map built from `f`. Note that [zigzag_glue_map_tri] depends heavily on the exact homotopy used here. *)
   Definition zigzag_glue_map : DiagramMap A B.
   Proof.
     snrapply Build_DiagramMap.
     - exact f.
-    - intros n m y x; destruct y.
+    - intros n m [] x.
       lhs apply (L n).
       apply ap.
       exact (U n x)^.
@@ -311,7 +308,7 @@ Section Interme.
   Proof.
     snrapply Build_DiagramMap.
     - exact g.
-    - intros n m y x; destruct y.
+    - intros n m [] x.
       lhs apply (U (S n)).
       apply ap.
       exact (L n x)^.
@@ -327,7 +324,7 @@ Section Interme.
       simpl.
       exact (U n x)^.
     - (* Conduct "a little path algebra" *) 
-      intros n m y x; destruct y.
+      intros n m [] x.
       simpl.
       unfold CommutativeSquares.comm_square_comp.
       (* We need to show, stripping brackets:
@@ -340,29 +337,29 @@ Section Interme.
       6) @ 1
        *)
       (* Bring the concatenation out of `ap` in 3) *)
-      rewrite (ap_pp (g n.+1) (L n (f n x)) (ap (f n.+1) (U n x)^)).
+      lhs nrapply (1 @@ ap_pp (g n.+1) (L n (f n x)) (ap (f n.+1) (U n x)^) @@ 1).
       (* Bring the inverse out of `ap` in 1) *)
-      rewrite (ap_V _ (L n (f n x))).
+      lhs nrapply (1 @@ ap_V (g n.+1) (L n (f n x)) @@ 1 @@ 1).
       (* Remove reflexivity 6) *)
       rhs apply (concat_p1 (ap (fun a => a ^+) (U n x)^)).
       (* Change associativity of 1 2 3 *)
-      rewrite (concat_pp_p (U n.+1 _) ((ap (g n.+1) _)^) _).
+      lhs nrapply (concat_pp_p (U n.+1 _) ((ap (g n.+1) _)^) _ @@ 1).
       (* Change associativity of 2 3 3.5 *)
-      rewrite (concat_p_pp ((ap _ _)^) (ap _ _) _).
+      lhs nrapply (1 @@ concat_p_pp ((ap _ _)^) (ap _ _) _ @@ 1).
       (* 2 and 3 are inverse *)
-      rewrite (concat_Vp _).
+      lhs nrapply (1 @@ (concat_Vp (ap (g n.+1) (L n (f n x))) @@ 1) @@ 1).
       (* Remove the reflexivity *)
-      rewrite (concat_1p _).
+      lhs nrapply (1 @@ concat_1p _ @@ 1).
       (* Add (U n.+1 x ^* ) on the right to both sides *)
       apply (cancelR _ _ ((U n.+1 x ^+))).
       (* Change associativity on the left... *)
-      lhs refine (concat_pp_p _ _ _).
+      lhs nrapply (concat_pp_p _ _ _).
       (* ...and cancel 4 with the newly-added path *)
-      rewrite (concat_Vp _).
+      lhs nrapply (1 @@ concat_Vp _).
       (* Remove the residual 1 *)
-      rewrite (concat_p1 _).
+      lhs nrapply (concat_p1 _).
       (* `ap` of `ap` is `ap` of composition of functions *)
-      rewrite (ap_compose (f n.+1) (g n.+1) _)^.
+      lhs nrapply (1 @@ ap_compose (f n.+1) (g n.+1) _)^.
       (* Finish by naturality of `ap` *)
       exact (concat_Ap _ _)^.
   Defined.
@@ -373,8 +370,8 @@ End Interme.
 
 Section Interleaving.
   Context `{Funext} {A B : Sequence} 
-    {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
-    {transfinite_B : Type} (col_B : IsColimit B transfinite_B)
+    {A_w : Type} (colim_A : IsColimit A A_w)
+    {B_w : Type} (colim_B : IsColimit B B_w)
     (f : forall (n : nat), A n -> B n)
     (g : forall (n : nat), B n -> A (S n))
     (U : forall (n : nat), (fun (x : A n) => x^+) == (g n) o (f n))
@@ -409,8 +406,8 @@ Section Interleaving.
       + reflexivity.
       + intros n m y x; destruct y. 
         simpl.
-        rewrite (concat_1p _).
-        rewrite (concat_p1 _).
+        rhs nrapply (concat_1p _).
+        lhs nrapply (concat_p1 _).
         reflexivity.
     - exact (transport (fun x => diagram_comp x u = seq_to_succ_seq B) eq^ attempt).
   Defined.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -1,0 +1,144 @@
+Require Import Basics.
+Require Import Colimits.Pushout.
+Require Import Spaces.Nat.
+Require Import Basics.Tactics.
+Require Import Diagrams.Cocone.
+Require Import Diagrams.Diagram.
+Require Import Diagrams.Sequence.
+(* Require Import Diagrams.Graph. *)
+Require Import WildCat.
+Require Import Colimits.Colimit.
+Require Import Colimits.Sequential.
+Require Import Diagram.
+Require Import Types.
+
+(** Suppose we have sequences A_i and B_i. An interleaving from 
+    A_i to B_i consists of two natural transformations
+    d : A_i => B_i (d for down) and u : B_i => A_i+1 (u for up), 
+    such that the composites (u o d) and (d o i) corresponds to 
+    the morphisms in the diagram itself. In other words,
+    the following diagram is commutative: 
+    
+    A_0 ----------> A_1 ------->
+        \         ^    \        ^ 
+         \       /      \      /  
+          \     /        \    /         ...
+           v   /          v  /
+            B_0 --------> B_1 ------->
+    
+    Given the setup above, we want to say that the colimit of the 
+    upper lower sequences are the same. *)
+
+(** From a sequence A, we can produce a diagram map from [A] to [succ_seq A]. 
+    It's the map that applies the arrow in the sequence to every element. *)
+
+Definition seq_to_succ_seq (A : Sequence) : DiagramMap A (succ_seq A).
+Proof.
+    snrapply Build_DiagramMap.
+    - intros n a. exact a^+. 
+    - intros m n [] x. reflexivity.
+Defined.
+
+(** Given a map of sequences we can define a map between 
+    their succesor sequences. *)
+
+Definition succ_seq_map_seq_map {A B : Sequence} (f : DiagramMap A B) 
+    : DiagramMap (succ_seq A) (succ_seq B).
+Proof.
+ snrapply Build_DiagramMap.
+ - intros n a. exact (f (S n) a).
+ - intros m n [] a. exact (DiagramMap_comm f _ a).
+Defined.
+
+(** We need some lemmata involving coherences in transfinite compositions. *)
+
+Section Transfinite_composition.
+    Context `{Funext} {A : Sequence}
+        (transfinite_A : Type) (col_A : IsColimit A transfinite_A)
+        (transfinite_succ_A : Type) (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A).
+
+    (** This is a map colim [succ_seq A] to colim [A] *)
+
+    Definition abs_colim_succ_seq_to_abs_colim_seq
+        : transfinite_succ_A -> transfinite_A.
+    Proof.
+        apply (cocone_postcompose_inv col_succ_A).
+        srapply Build_Cocone.
+        - intros n a. exact (col_A (S n) a).
+        - intros m n [] a. exact (legs_comm col_A _ _ _ _).
+    Defined.
+
+    (** This is a map colim [A] to colim [succ_seq A] *)
+
+    Definition abs_colim_seq_to_abs_colim_succ_seq
+        : transfinite_A -> transfinite_succ_A.
+    Proof.
+        apply (cocone_postcompose_inv col_A).
+        srapply Build_Cocone.
+        - intros n a. exact (col_succ_A n a^+).
+        - intros m n [] a. exact (legs_comm col_succ_A m (S m) idpath a^+).
+    Defined.
+
+    (** We hope that these maps are quasi-inverses of each other *)
+
+    Definition equiv_abs_colim_succ_seq_to_abs_colim_seq
+        : IsEquiv abs_colim_succ_seq_to_abs_colim_seq.
+    Proof.
+        snrapply isequiv_adjointify.
+        - exact abs_colim_seq_to_abs_colim_succ_seq.
+        - intro a. 
+    Admitted.
+
+End Transfinite_composition.
+
+(** Intersplitting is a pun of interleaving and splitting. 
+    We will at first only assume that every other triangle
+    is commutative. Intuitively, one may think of A as a retract of B. 
+    We then expect colim A to be a retract of colim B as well. *)
+
+Section Intersplitting.
+    Context `{Funext} {A B : Sequence} 
+        (transfinite_A : Type) (col_A : IsColimit A transfinite_A)
+        (transfinite_succ_A : Type) (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A)
+        (transfinite_B : Type) (col_B : IsColimit B transfinite_B)
+        (d : DiagramMap A B) 
+        (u : DiagramMap B (succ_seq A))
+        (comm_triangle : seq_to_succ_seq A = diagram_comp u d).
+    
+    (** Given the data above, we show that the associated diagram in the
+        colimit is also commutative.
+
+        col A_i -----> col A_i+1
+            \           ^
+             \         /
+              \       /
+               v     /
+              col B_i
+    *)
+
+    Definition colimit_comm_triangle : 
+        (functor_colimit (seq_to_succ_seq A) col_A col_succ_A) 
+          = (functor_colimit u _ _) o (functor_colimit d _ _).
+    Proof.
+        rhs snrapply functoriality_functor_colimit.
+        rhs refine (ap (fun x => functor_colimit x col_A col_succ_A) 
+            comm_triangle^).
+        reflexivity.
+    Defined.
+
+
+
+End Intersplitting.
+
+(** Now we will assume that every triangle is commutative. *)
+
+Section Interleaving.
+    Context {A B : Sequence} 
+        (transfiniteA : Type) (colA : IsColimit A transfiniteA)
+        (transfiniteB : Type) (colB : IsColimit B transfiniteB)
+        (d : DiagramMap A B) 
+        (u : DiagramMap B (succ_seq A))
+        (tri1 : seq_to_succ_seq A = diagram_comp u d)
+        (tri2 : seq_to_succ_seq B = diagram_comp (succ_seq_map_seq_map d) u).
+
+End Interleaving.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -12,9 +12,8 @@ Require Import Colimits.Sequential.
 Require Import Diagram.
 Require Import Types.
 
-(** Suppose we have sequences [A_i] and [B_i]. An interleaving from [A_i] to [B_i] consists of two natural transformations d : A_i => B_i (d for down) and u : B_i => A_i+1 (u for up), such that the composites (u o d) and (d o i) correspond to the morphisms in the diagram itself. In other words, the following diagram is commutative: *)
-    
-(**  
+(** Suppose we have sequences [A_i] and [B_i]. An interleaving from [A_i] to [B_i] consists of two natural transformations d : A_i => B_i (d for down) and u : B_i => A_i+1 (u for up), such that the composites (u o d) and (d o i) correspond to the morphisms in the diagram itself. In other words, the following diagram is commutative:
+
 <<
     A_0 -------> A_1 ------> A_2 ------>
         \        ^  \        ^ 
@@ -22,10 +21,9 @@ Require Import Types.
           \    /      \    /         ...
            v  /        v  /
            B_0 ------> B_1 ------->
->> 
-*)
+>>
 
-(** Given the setup above, we want to say that the colimit of the upper lower sequences are the same. From a sequence A, we can produce a diagram map from [A] to [succ_seq A]. It's the map that applies the arrow in the sequence to every element. *)
+Given the setup above, we want to say that the colimit of the upper lower sequences are the same. From a sequence A, we can produce a diagram map from [A] to [succ_seq A]. It's the map that applies the arrow in the sequence to every element. *)
 
 Definition seq_to_succ_seq (A : Sequence) : DiagramMap A (succ_seq A).
 Proof.
@@ -99,9 +97,8 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
     : Cocone (succ_seq A) A_w
     := succ_seq_cocone_seq_cocone A_w colim_A.
 
-  (** We start by showing that [abstr_colim_seq_to_abstr_colim_succ_seq] is a split-monomorphism. Observe that [cocone_succ_seq_over_col] essentially defines the same cocone as [colim_A]. I.e. the following  diagram is commutative: *)
+  (** We start by showing that [abstr_colim_seq_to_abstr_colim_succ_seq] is a split-monomorphism. Observe that [cocone_succ_seq_over_col] essentially defines the same cocone as [colim_A]. I.e. the following  diagram is commutative:
   
-  (**
   <<
                   A          succ_seq A
                ______          ______
@@ -335,29 +332,21 @@ Section Interme.
       6) @ 1
        *)
       (* Bring the concatenation out of `ap` in 3) *)
-      lhs nrapply (1 @@ ap_pp (g n.+1) (L n (f n x)) (ap (f n.+1) (U n x)^) @@ 1).
-      (* Bring the inverse out of `ap` in 1) *)
-      lhs nrapply (1 @@ ap_V (g n.+1) (L n (f n x)) @@ 1 @@ 1).
       (* Remove reflexivity 6) *)
-      rhs apply (concat_p1 (ap (fun a => a ^+) (U n x)^)).
-      (* Change associativity of 1 2 3 *)
-      lhs nrapply (concat_pp_p (U n.+1 _) ((ap (g n.+1) _)^) _ @@ 1).
-      (* Change associativity of 2 3 3.5 *)
-      lhs nrapply (1 @@ concat_p_pp ((ap _ _)^) (ap _ _) _ @@ 1).
-      (* 2 and 3 are inverse *)
-      lhs nrapply (1 @@ (concat_Vp (ap (g n.+1) (L n (f n x))) @@ 1) @@ 1).
-      (* Remove the reflexivity *)
-      lhs nrapply (1 @@ concat_1p _ @@ 1).
+      rhs nrapply (concat_p1 _).
       (* Add (U n.+1 x ^* ) on the right to both sides *)
-      apply (cancelR _ _ ((U n.+1 x ^+))).
-      (* Change associativity on the left... *)
-      lhs nrapply (concat_pp_p _ _ _).
-      (* ...and cancel 4 with the newly-added path *)
-      lhs nrapply (1 @@ concat_Vp _).
-      (* Remove the residual 1 *)
-      lhs nrapply (concat_p1 _).
+      apply moveR_pV.
+      (* lhs nrefine (1 @@ _ @@ 1). *)
+      lhs nrapply (1 @@ ap_pp (g n.+1) (L n (f n x)) (ap (f n.+1) (U n x)^)).
+      (* Bring the inverse out of `ap` in 1) *)
+      lhs nrapply (1 @@ ap_V (g n.+1) (L n (f n x)) @@ 1).
+      (* Change associativity of 1 2 3 *)
+      lhs nrapply (concat_pp_p (U n.+1 _) ((ap (g n.+1) _)^) _).
+      
+      (* Change associativity of 2 3 3.5 *)
+      lhs nrapply (1 @@ concat_V_pp _ _).
       (* `ap` of `ap` is `ap` of composition of functions *)
-      lhs nrapply (1 @@ ap_compose (f n.+1) (g n.+1) _)^.
+      lhs_V nrapply (1 @@ ap_compose (f n.+1) (g n.+1) _).
       (* Finish by naturality of `ap` *)
       exact (concat_Ap _ _)^.
   Defined.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -331,24 +331,24 @@ Section Interme.
       5)  ap (fun a : A n.+1%nat => a ^+) (U n x)^ 
       6) @ 1
        *)
-      (* Bring the concatenation out of `ap` in 3) *)
-      (* Remove reflexivity 6) *)
+      Open Scope long_path_scope.
+      (* Concatenate reflexivity path *)
       rhs nrapply (concat_p1 _).
-      (* Add (U n.+1 x ^* ) on the right to both sides *)
+      (* Move [U n.+1 x] to the left hand side on the right *)
       apply moveR_pV.
-      (* lhs nrefine (1 @@ _ @@ 1). *)
+      (* Split up ap on concatenations *)
       lhs nrapply (1 @@ ap_pp (g n.+1) (L n (f n x)) (ap (f n.+1) (U n x)^)).
       (* Bring the inverse out of `ap` in 1) *)
       lhs nrapply (1 @@ ap_V (g n.+1) (L n (f n x)) @@ 1).
       (* Change associativity of 1 2 3 *)
       lhs nrapply (concat_pp_p (U n.+1 _) ((ap (g n.+1) _)^) _).
-      
-      (* Change associativity of 2 3 3.5 *)
+      (* Cancel term by associativity *)
       lhs nrapply (1 @@ concat_V_pp _ _).
       (* `ap` of `ap` is `ap` of composition of functions *)
       lhs_V nrapply (1 @@ ap_compose (f n.+1) (g n.+1) _).
       (* Finish by naturality of `ap` *)
       exact (concat_Ap _ _)^.
+      Close Scope long_path_scope.
   Defined.
 End Interme.
 

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -25,9 +25,7 @@ Require Import Types.
 >> 
 *)
 
-(** Given the setup above, we want to say that the colimit of the upper lower sequences are the same. *)
-
-(** From a sequence A, we can produce a diagram map from [A] to [succ_seq A]. It's the map that applies the arrow in the sequence to every element. *)
+(** Given the setup above, we want to say that the colimit of the upper lower sequences are the same. From a sequence A, we can produce a diagram map from [A] to [succ_seq A]. It's the map that applies the arrow in the sequence to every element. *)
 
 Definition seq_to_succ_seq (A : Sequence) : DiagramMap A (succ_seq A).
 Proof.
@@ -66,12 +64,12 @@ Proof.
   snrapply isequiv_adjointify.
   - exact (succ_seq_cocone_seq_cocone X).
   - intro C.
-    srapply path_cocone.
+    snrapply path_cocone.
     + intro n. simpl. exact (legs_comm C n _ idpath).
     + intros m n [] a. simpl.
       exact (concat_1p _ @@ 1).
   - intro C.
-    srapply path_cocone.
+    snrapply path_cocone.
     + intro n. simpl. exact (legs_comm C n _ idpath).
     + intros m n [] a. simpl.
       exact (concat_1p _ @@ 1).
@@ -83,10 +81,10 @@ Definition col_legs_induces_idmap `{Funext} {A : Sequence}
   {A_w} (colim_A : IsColimit A A_w) 
   : cocone_postcompose_inv colim_A colim_A = idmap.
 Proof.
-  rapply (equiv_inj (cocone_postcompose colim_A)).
+  snrapply (equiv_inj (cocone_postcompose colim_A)).
   - exact (iscolimit_unicocone colim_A A_w).
-  - lhs snrapply (eisretr (cocone_postcompose colim_A)).
-    snrapply (cocone_postcompose_identity colim_A)^.
+  - lhs nrapply (eisretr (cocone_postcompose colim_A)).
+    exact (cocone_postcompose_identity colim_A)^.
 Defined.
 
 (** We show that the map induced by [succ_seq_to_seq] is an equivalence. *)
@@ -99,7 +97,7 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
 
   Definition cocone_succ_seq_over_col 
     : Cocone (succ_seq A) A_w
-  := succ_seq_cocone_seq_cocone A_w colim_A.
+    := succ_seq_cocone_seq_cocone A_w colim_A.
 
   (** We start by showing that [abstr_colim_seq_to_abstr_colim_succ_seq] is a split-monomorphism. Observe that [cocone_succ_seq_over_col] essentially defines the same cocone as [colim_A]. I.e. the following  diagram is commutative: *)
   
@@ -119,11 +117,11 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
   Definition legs_comm_cocone_succ_seq_over_col_with_col 
     (n : sequence_graph) 
     : cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col n
-    == colim_A n := (legs_comm (iscolimit_cocone colim_A) _ _ _).
+      == colim_A n := (legs_comm (iscolimit_cocone colim_A) _ _ _).
 
   Definition cocone_succ_seq_over_col_is_ess_col 
     : cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col
-    = iscolimit_cocone colim_A.
+      = iscolimit_cocone colim_A.
   Proof.
     apply (path_cocone 
       legs_comm_cocone_succ_seq_over_col_with_col).
@@ -144,16 +142,16 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
     exact (cocone_postcompose_inv colim_A (cocone_precompose (seq_to_succ_seq A) C)).
   - intro C.
     snrapply (equiv_inj (cocone_precompose (seq_to_succ_seq A))).
-    + exact (isequiv_cocone_precompose_seq_to_succ_seq (X:= Y)).
-    + lhs_V snrapply cocone_precompose_postcompose.
-      lhs snrapply (ap (fun x => cocone_postcompose x _)
+    + exact (isequiv_cocone_precompose_seq_to_succ_seq (X:=Y)).
+    + lhs_V nrapply cocone_precompose_postcompose.
+      lhs nrapply (ap (fun x => cocone_postcompose x _)
         cocone_succ_seq_over_col_is_ess_col).
-      snrapply (eisretr (cocone_postcompose colim_A)).
+      nrapply (eisretr (cocone_postcompose colim_A)).
   - intro f.
-    snrapply (equiv_inj (cocone_postcompose colim_A)).
+    nrapply (equiv_inj (cocone_postcompose colim_A)).
     + exact (iscolimit_unicocone colim_A Y).
-    + lhs snrapply (eisretr (cocone_postcompose colim_A)).
-      lhs_V snrapply cocone_precompose_postcompose.
+    + lhs nrapply (eisretr (cocone_postcompose colim_A)).
+      lhs_V nrapply cocone_precompose_postcompose.
       exact (ap (fun x => cocone_postcompose x f) cocone_succ_seq_over_col_is_ess_col).
   Defined.
 
@@ -165,7 +163,7 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
 
   Definition abstr_colim_seq_to_abstr_colim_succ_seq
     : A_w -> A_w 
-  := functor_colimit (seq_to_succ_seq A) colim_A colim_succ.
+    := functor_colimit (seq_to_succ_seq A) colim_A colim_succ.
 
   Definition abstr_colim_seq_to_abstr_colim_succ_seq_is_idmap
     : abstr_colim_seq_to_abstr_colim_succ_seq = idmap.
@@ -183,7 +181,7 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
 
   Definition abstr_colim_succ_seq_to_abstr_colim_seq
     : A_w -> A_w 
-  := (cocone_postcompose_inv colim_succ cocone_succ_seq_over_col).
+    := (cocone_postcompose_inv colim_succ cocone_succ_seq_over_col).
 
   Definition abstr_colim_succ_seq_to_abstr_colim_seq_is_idmap
     : abstr_colim_succ_seq_to_abstr_colim_seq = idmap.
@@ -201,7 +199,7 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
   Definition sec_abstr_colim_seq_to_abstr_succ_seq
     : abstr_colim_succ_seq_to_abstr_colim_seq
     o abstr_colim_seq_to_abstr_colim_succ_seq
-    = idmap.
+      = idmap.
   Proof.
     lhs nrapply (ap _ abstr_colim_seq_to_abstr_colim_succ_seq_is_idmap).
     exact abstr_colim_succ_seq_to_abstr_colim_seq_is_idmap.
@@ -210,7 +208,7 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
   Definition ret_abstr_colim_seq_to_abstr_succ_seq
     : abstr_colim_seq_to_abstr_colim_succ_seq 
     o abstr_colim_succ_seq_to_abstr_colim_seq
-    = idmap.
+      = idmap.
   Proof.
     lhs nrapply (ap _ abstr_colim_seq_to_abstr_colim_succ_seq_is_idmap).
     exact abstr_colim_succ_seq_to_abstr_colim_seq_is_idmap.
@@ -258,7 +256,7 @@ Section Intersplitting.
 
   Definition colimit_comm_triangle : 
     abstr_colim_seq_to_abstr_colim_succ_seq colim_A
-    = (functor_colimit u _ (colim_succ colim_A)) o (functor_colimit d _ _).
+      = (functor_colimit u _ (colim_succ colim_A)) o (functor_colimit d _ _).
   Proof.
     rhs nrapply functor_colimit_compose.
     exact (ap (fun x => functor_colimit x colim_A (colim_succ colim_A)) 
@@ -267,7 +265,7 @@ Section Intersplitting.
 
   Definition colim_d_split_epi : 
     idmap = (functor_colimit u _ (colim_succ colim_A)) o (functor_colimit d _ _)
-  := ((abstr_colim_seq_to_abstr_colim_succ_seq_is_idmap colim_A)^ @ colimit_comm_triangle).
+    := ((abstr_colim_seq_to_abstr_colim_succ_seq_is_idmap colim_A)^ @ colimit_comm_triangle).
 
   Definition isequiv_colim_composite
     : IsEquiv ((functor_colimit u colim_B (colim_succ colim_A)) 
@@ -386,7 +384,7 @@ Section Interleaving.
 
   (* The first equality needed is exactly what we came up with in the previous section. *)
   Let tri1 : seq_to_succ_seq A = diagram_comp u d
-    := (zigzag_glue_map_tri f g U L)^.
+   := (zigzag_glue_map_tri f g U L)^.
 
   (* The second one requires some massaging: applying [zigzag_glue_map_tr] to the shifted 
   functions doesn't exactly give us `(succ_seq_map_seq_map d)`, but we can find an equality
@@ -395,27 +393,26 @@ Section Interleaving.
   Let tri2 : seq_to_succ_seq B = diagram_comp (succ_seq_map_seq_map d) u.
   Proof.
     symmetry.
-    pose (f' := g);
-    pose (g' := (fun n => f (S n)));
-    pose (U' := L);
-    pose (L' := (fun n => U (S n)));
+    pose (f':=g);
+    pose (g':=(fun n => f (S n)));
+    pose (U':=L);
+    pose (L':=(fun n => U (S n)));
     (* Coq can't guess `succ_seq A` here *)
-    pose (attempt := (@zigzag_glue_map_tri _ B (succ_seq A) f' g' U' L')).
+    pose (attempt:=(@zigzag_glue_map_tri _ B (succ_seq A) f' g' U' L')).
     assert (eq : (succ_seq_map_seq_map d) = (@zigzag_glue_map_inv B (succ_seq A) f' g' U' L')).
     - snrapply path_DiagramMap.
       + reflexivity.
       + intros n m y x; destruct y. 
         simpl.
         rhs nrapply (concat_1p _).
-        lhs nrapply (concat_p1 _).
-        reflexivity.
+        nrapply (concat_p1 _).
     - exact (transport (fun x => diagram_comp x u = seq_to_succ_seq B) eq^ attempt).
   Defined.
 
   Definition isequiv_interleaved_colim_maps
-    : IsEquiv (functor_colimit d _ _) * IsEquiv (functor_colimit u _ (colim_succ colim_A)) * IsEquiv (functor_colimit (succ_seq_map_seq_map d) (colim_succ colim_A) (colim_succ colim_B)).
+    : IsEquiv (functor_colimit d _ _).
   Proof.
-    snrapply two_out_of_six.
+    nrapply two_out_of_sixR.
     - exact (isequiv_colim_composite colim_A colim_B d u tri1).
     - exact (isequiv_colim_composite colim_B (colim_succ colim_A) u 
       (succ_seq_map_seq_map d) tri2).
@@ -425,6 +422,6 @@ Section Interleaving.
   Proof.
     snrapply Build_Equiv.
     - exact (functor_colimit d colim_A colim_B).
-    - exact ((fst o fst) isequiv_interleaved_colim_maps).
+    - exact isequiv_interleaved_colim_maps.
   Defined.
 End Interleaving.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -292,6 +292,61 @@ Section Intersplitting.
 
 End Intersplitting.
 
+Section Interme.
+  Context `{Funext} {A B : Sequence}
+    (f : forall (n : nat), A n -> B n)
+    (g : forall (n : nat), B n -> A (S n))
+    (U : forall (n : nat), (fun (x : A n) => x^+) == (g n) o (f n))
+    (L : forall (n : nat), (fun (x : B n) => x^+) == (f (S n)) o (g n)).
+
+  Definition zigzag_map : DiagramMap A B.
+  Proof.
+    snrapply Build_DiagramMap.
+    - exact f.
+    - intros n m y x; destruct y.
+      lhs apply (L n).
+      apply ap.
+      exact (U n x)^.
+  Defined.
+
+  Definition zigzag_map_inv : DiagramMap B (succ_seq A).
+  Proof.
+    snrapply Build_DiagramMap.
+    - exact g.
+    - intros n m y x; destruct y.
+      lhs apply (U (S n)).
+      apply ap.
+      exact (L n x)^.
+  Defined.
+
+  Local Open Scope path_scope.
+
+  Definition zigzag_map_tr : (diagram_comp zigzag_map_inv zigzag_map) = seq_to_succ_seq A.
+  Proof.
+    snrapply path_DiagramMap.
+    - intros n x.
+      simpl.
+      exact (U n x)^.
+    - (* Conduct "a little path algebra" *) 
+      intros n m y x; destruct y.
+      simpl.
+      unfold CommutativeSquares.comm_square_comp.
+      rewrite (ap_pp (g n.+1) (L n (f n x)) (ap (f n.+1) (U n x)^)).
+      rewrite (ap_V _ (L n (f n x))).
+      rhs apply (concat_p1 (ap (fun a => a ^+) (U n x)^)).
+      rewrite (concat_pp_p (U n.+1 _) ((ap (g n.+1) _)^) _).
+      rewrite (concat_p_pp ((ap _ _)^) (ap _ _) _).
+      rewrite (concat_Vp _).
+      rewrite (concat_1p _).
+      apply (cancelR _ _ ((U n.+1 x ^+))).
+      lhs refine (concat_pp_p _ _ _).
+      rewrite (concat_Vp _).
+      rewrite (concat_p1 _).
+      rewrite (ap_compose (f n.+1) (g n.+1) _)^.
+      refine (concat_Ap _ _)^.
+  Defined.
+End Interme.
+
 (** Assuming that there are [A, B : Sequence] that fits in an interleaving diagram,
     their colimits are isomorphic. We proceed by using th 2-out-of-6 property.  *)
 

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -71,23 +71,33 @@ Section Transfinite_composition.
     (** This is a map colim [A] to colim [succ_seq A] *)
 
     Definition abs_colim_seq_to_abs_colim_succ_seq
-        : transfinite_A -> transfinite_succ_A.
-    Proof.
-        apply (cocone_postcompose_inv col_A).
-        srapply Build_Cocone.
-        - intros n a. exact (col_succ_A n a^+).
-        - intros m n [] a. exact (legs_comm col_succ_A m (S m) idpath a^+).
-    Defined.
+        : transfinite_A -> transfinite_succ_A 
+    := functor_colimit (seq_to_succ_seq A) _ _.
 
     (** We hope that these maps are quasi-inverses of each other *)
+    
+        (** Hack while I think about this property *)
+
+        Definition ret_abs_colim_succ_seq_to_abs_seq
+            : abs_colim_seq_to_abs_colim_succ_seq 
+                o abs_colim_succ_seq_to_abs_colim_seq
+                == idmap.
+        Admitted.
+
+        Definition sec_abs_colim_succ_seq_to_abs_seq
+            : abs_colim_succ_seq_to_abs_colim_seq
+                o abs_colim_seq_to_abs_colim_succ_seq
+                == idmap.
+        Admitted.
 
     Definition equiv_abs_colim_succ_seq_to_abs_colim_seq
         : IsEquiv abs_colim_succ_seq_to_abs_colim_seq.
     Proof.
         snrapply isequiv_adjointify.
         - exact abs_colim_seq_to_abs_colim_succ_seq.
-        - intro a. 
-    Admitted.
+        - exact sec_abs_colim_succ_seq_to_abs_seq.
+        - exact ret_abs_colim_succ_seq_to_abs_seq.
+    Defined.
 
 End Transfinite_composition.
 
@@ -125,8 +135,6 @@ Section Intersplitting.
             comm_triangle^).
         reflexivity.
     Defined.
-
-
 
 End Intersplitting.
 

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -224,7 +224,7 @@ Section Is_Equiv_colim_succ_seq_to_seq_map.
 
 End Is_Equiv_colim_succ_seq_to_seq_map.
 
-(** Intersplitting is a pun of interleaving and splitting. We will at first only assume that every other triangle is commutative. In this case, colim A is a retract of colim B. *)
+(**  In intersplitting we will only assume that every other triangle is commutative. In this case, colim A is a retract of colim B. *)
 
 Section Intersplitting.
   Context `{Funext} {A B : Sequence} 
@@ -235,9 +235,8 @@ Section Intersplitting.
     (comm_triangle : seq_to_succ_seq A = diagram_comp u d).
     
   (** Given the data above, we show that the associated diagram in the
-      colimit is also commutative. *)
+      colimit is also commutative.
 
-  (**
   <<
                   id
         col A_i -----> col A_i+1
@@ -247,9 +246,8 @@ Section Intersplitting.
                v     /
               col B_i
   >>
-  *)
-
-  (** It follows that d is split-epi, and u is split-mono, as desired. *)
+  
+  It follows that d is split-epi, and u is split-mono, as desired. *)
 
   Definition colimit_comm_triangle : 
     abstr_colim_seq_to_abstr_colim_succ_seq colim_A
@@ -278,7 +276,7 @@ Section Intersplitting.
 
 End Intersplitting.
 
-(** Given families of maps `f n : A n -> B n` and `g : B n -> A (n + 1)` with homotopies showing that they form zigzags, construct the actual diagram maps and show that their composition is equal to the successor diagram map. *)
+(** Given families of maps [f n : A n -> B n] and [g : B n -> A (n + 1)] with homotopies showing that they form zigzags, construct the actual diagram maps and show that their composition is equal to the successor diagram map. *)
 
 Section Interme.
   Context `{Funext} {A B : Sequence}
@@ -287,7 +285,7 @@ Section Interme.
     (U : forall (n : nat), (fun (x : A n) => x^+) == (g n) o (f n))
     (L : forall (n : nat), (fun (x : B n) => x^+) == (f (S n)) o (g n)).
 
-  (** The map built from `f`. Note that [zigzag_glue_map_tri] depends heavily on the exact homotopy used here. *)
+  (** The map built from [f]. Note that [zigzag_glue_map_tri] depends heavily on the exact homotopy used here. *)
   Definition zigzag_glue_map : DiagramMap A B.
   Proof.
     snrapply Build_DiagramMap.
@@ -298,7 +296,7 @@ Section Interme.
       exact (U n x)^.
   Defined.
 
-  (** The map built from `g`. *)
+  (** The map built from [g]. *)
   Definition zigzag_glue_map_inv : DiagramMap B (succ_seq A).
   Proof.
     snrapply Build_DiagramMap.
@@ -323,13 +321,13 @@ Section Interme.
       simpl.
       unfold CommutativeSquares.comm_square_comp.
       (* We need to show, stripping brackets:
-      1)   U n.+1 (g n (f n x))
-      2) @ ap (g n.+1) (L n (f n x))^) 
-      3) @ ap (g n.+1) (L n (f n x) @ ap (f n.+1) (U n x)^)
-      4) @ (U n.+1 x ^+)^ 
-          = 
-      5)  ap (fun a : A n.+1%nat => a ^+) (U n x)^ 
-      6) @ 1
+      1)   [U n.+1 (g n (f n x))]
+      2) [@ ap (g n.+1) (L n (f n x))^)] 
+      3) [@ ap (g n.+1) (L n (f n x) @ ap (f n.+1) (U n x)^)]
+      4) [@ (U n.+1 x ^+)^ ]
+          [=] 
+      5)  [ap (fun a : A n.+1%nat => a ^+) (U n x)^] 
+      6) [@ 1]
        *)
       Open Scope long_path_scope.
       (* Concatenate reflexivity path *)
@@ -338,15 +336,15 @@ Section Interme.
       apply moveR_pV.
       (* Split up ap on concatenations *)
       lhs nrapply (1 @@ ap_pp (g n.+1) (L n (f n x)) (ap (f n.+1) (U n x)^)).
-      (* Bring the inverse out of `ap` in 1) *)
+      (* Bring the inverse out of [ap] in 1) *)
       lhs nrapply (1 @@ ap_V (g n.+1) (L n (f n x)) @@ 1).
       (* Change associativity of 1 2 3 *)
       lhs nrapply (concat_pp_p (U n.+1 _) ((ap (g n.+1) _)^) _).
       (* Cancel term by associativity *)
       lhs nrapply (1 @@ concat_V_pp _ _).
-      (* `ap` of `ap` is `ap` of composition of functions *)
+      (* [ap] of [ap] is [ap] of composition of functions *)
       lhs_V nrapply (1 @@ ap_compose (f n.+1) (g n.+1) _).
-      (* Finish by naturality of `ap` *)
+      (* Finish by naturality of [ap] *)
       exact (concat_Ap _ _)^.
       Close Scope long_path_scope.
   Defined.
@@ -369,14 +367,14 @@ Section Interleaving.
   Let u := zigzag_glue_map_inv f g U L.
   
   (* We need two equalities: [seq_to_succ_seq A = d o u] and 
-  [seq_to_succ_seq B = (succ_seq_map_seq_map d) o u. *)
+  [seq_to_succ_seq B = (succ_seq_map_seq_map d) o u]. *)
 
   (* The first equality needed is exactly what we came up with in the previous section. *)
   Let tri1 : seq_to_succ_seq A = diagram_comp u d
    := (zigzag_glue_map_tri f g U L)^.
 
   (* The second one requires some massaging: applying [zigzag_glue_map_tr] to the shifted 
-  functions doesn't exactly give us `(succ_seq_map_seq_map d)`, but we can find an equality
+  functions doesn't exactly give us [succ_seq_map_seq_map d], but we can find an equality
   between them. *)
   (* TODO: This probably shouldn't be necessary. *)
   Let tri2 : seq_to_succ_seq B = diagram_comp (succ_seq_map_seq_map d) u.
@@ -386,7 +384,7 @@ Section Interleaving.
     pose (g':=(fun n => f (S n)));
     pose (U':=L);
     pose (L':=(fun n => U (S n)));
-    (* Coq can't guess `succ_seq A` here *)
+    (* Coq can't guess [succ_seq A] here *)
     pose (attempt:=(@zigzag_glue_map_tri _ B (succ_seq A) f' g' U' L')).
     assert (eq : (succ_seq_map_seq_map d) = (@zigzag_glue_map_inv B (succ_seq A) f' g' U' L')).
     - snrapply path_DiagramMap.

--- a/theories/PushoutPath/Interleaving.v
+++ b/theories/PushoutPath/Interleaving.v
@@ -2,10 +2,10 @@ Require Import Basics.
 Require Import Colimits.Pushout.
 Require Import Spaces.Nat.
 Require Import Basics.Tactics.
-Require Import Diagrams.Cocone.
+Require Import Diagrams.Graph.
 Require Import Diagrams.Diagram.
+Require Import Diagrams.Cocone.
 Require Import Diagrams.Sequence.
-(* Require Import Diagrams.Graph. *)
 Require Import WildCat.
 Require Import Colimits.Colimit.
 Require Import Colimits.Sequential.
@@ -19,12 +19,12 @@ Require Import Types.
     the morphisms in the diagram itself. In other words,
     the following diagram is commutative: 
     
-    A_0 ----------> A_1 ------->
-        \         ^    \        ^ 
-         \       /      \      /  
-          \     /        \    /         ...
-           v   /          v  /
-            B_0 --------> B_1 ------->
+    A_0 -------> A_1 ------> A_2 ------>
+        \        ^  \        ^ 
+         \      /    \      /  
+          \    /      \    /         ...
+           v  /        v  /
+           B_0 ------> B_1 ------->
     
     Given the setup above, we want to say that the colimit of the 
     upper lower sequences are the same. *)
@@ -50,56 +50,143 @@ Proof.
  - intros m n [] a. exact (DiagramMap_comm f _ a).
 Defined.
 
-(** We need some lemmata involving coherences in transfinite compositions. *)
+(** We show that the map induced by succ_seq_to_seq_map is an equivalence. *)
 
-Section Transfinite_composition.
+Section Is_Equiv_colim_succ_seq_to_seq_map.
     Context `{Funext} {A : Sequence}
-        (transfinite_A : Type) (col_A : IsColimit A transfinite_A)
-        (transfinite_succ_A : Type) (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A).
+        {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
+        {transfinite_succ_A : Type} 
+        (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A).
 
-    (** This is a map colim [succ_seq A] to colim [A] *)
+    (** This is a map [transfinite_A -> transfinite_succ_A] *)
 
-    Definition abs_colim_succ_seq_to_abs_colim_seq
-        : transfinite_succ_A -> transfinite_A.
+    Definition abs_colim_seq_to_abs_colim_succ_seq
+        : transfinite_A -> transfinite_succ_A 
+    := functor_colimit (seq_to_succ_seq A) col_A col_succ_A.
+
+    (** We make a cocone from [succ_seq A] to [transfinite_A] *)
+
+    Definition cocone_succ_seq_over_col 
+        : Cocone (succ_seq A) transfinite_A.
     Proof.
-        apply (cocone_postcompose_inv col_succ_A).
         srapply Build_Cocone.
         - intros n a. exact (col_A (S n) a).
         - intros m n [] a. exact (legs_comm col_A _ _ _ _).
     Defined.
 
-    (** This is a map colim [A] to colim [succ_seq A] *)
+    (** Using the cocone above, 
+        we obtain a map [transfinite_succ_A -> transfinite_A] *)
 
-    Definition abs_colim_seq_to_abs_colim_succ_seq
-        : transfinite_A -> transfinite_succ_A 
-    := functor_colimit (seq_to_succ_seq A) _ _.
+    Definition abs_colim_succ_seq_to_abs_colim_seq
+        : transfinite_succ_A -> transfinite_A := 
+        (cocone_postcompose_inv col_succ_A cocone_succ_seq_over_col).
 
-    (** We hope that these maps are quasi-inverses of each other *)
+    (** Our goal is to show that these maps are quasi-inverses
+        of each other. *)
     
-        (** Hack while I think about this property *)
+    (** We start with showing that [abs_colim_seq_to_abs_colim_succ_seq]
+        is a split-monomorphism. [cocone_succ_seq_over_col] defines 
+        essentially the same cocone as [col_A]. I.e. the following 
+        diagram is commutative:
+        
+                   A          succ_seq A
+                ______          ______
+               |      | =====>  \     |
+               |      |         /     |
+                ‾‾‾‾‾‾          ‾‾‾‾‾‾
+                     \  \     /  /
+                col_A \  \   /  / cocone_succ_seq_over_col
+                        colim A
+    
+        *)
 
-        Definition ret_abs_colim_succ_seq_to_abs_seq
-            : abs_colim_seq_to_abs_colim_succ_seq 
-                o abs_colim_succ_seq_to_abs_colim_seq
-                == idmap.
-        Admitted.
+    Definition legs_comm_cocone_succ_seq_over_col_with_col 
+        (n : sequence_graph) 
+        : cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col n
+         == col_A n := (legs_comm (iscolimit_cocone col_A) _ _ _).
 
-        Definition sec_abs_colim_succ_seq_to_abs_seq
-            : abs_colim_succ_seq_to_abs_colim_seq
-                o abs_colim_seq_to_abs_colim_succ_seq
-                == idmap.
-        Admitted.
-
-    Definition equiv_abs_colim_succ_seq_to_abs_colim_seq
-        : IsEquiv abs_colim_succ_seq_to_abs_colim_seq.
+    Definition cocone_succ_seq_over_col_is_ess_col 
+        : cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col
+        = iscolimit_cocone col_A.
     Proof.
-        snrapply isequiv_adjointify.
-        - exact abs_colim_seq_to_abs_colim_succ_seq.
-        - exact sec_abs_colim_succ_seq_to_abs_seq.
-        - exact ret_abs_colim_succ_seq_to_abs_seq.
+        apply (path_cocone 
+            legs_comm_cocone_succ_seq_over_col_with_col).
+        intros m n [] a. 
+        unfold legs_comm_cocone_succ_seq_over_col_with_col.
+        simpl.
+        lhs refine 
+            (ap (fun x => x @ legs_comm col_A m (S m) 1 a) (concat_1p _)).
+        reflexivity.
     Defined.
 
-End Transfinite_composition.
+    (** The cocone [col_A] indeces [idmap : transfinite_A -> transfinite_A]. *)
+
+    Definition col_legs_induces_idmap 
+        : cocone_postcompose_inv col_A col_A = idmap.
+    Proof.
+        apply (@equiv_inj _ _ (cocone_postcompose col_A)
+            (iscolimit_unicocone col_A transfinite_A) _ _).
+        lhs snrapply (eisretr (cocone_postcompose col_A)).
+        rhs snrapply (cocone_postcompose_identity col_A).
+        reflexivity.
+    Defined.
+
+    (** [cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col] 
+        induces the composite [abs_colim_succ_seq_to_abs_colim_seq
+        o abs_colim_seq_to_abs_colim_succ_seq] *)
+
+    Definition cocone_precompose_seq_to_succ_seq_cocone_succ_seq_over_col_induces_comp
+        : cocone_postcompose_inv col_A (cocone_precompose (seq_to_succ_seq A) cocone_succ_seq_over_col)
+            = abs_colim_succ_seq_to_abs_colim_seq
+            o abs_colim_seq_to_abs_colim_succ_seq. 
+    Proof.
+        apply (@equiv_inj _ _ (cocone_postcompose col_A)
+            (iscolimit_unicocone col_A transfinite_A) _ _).
+        rhs snrapply cocone_postcompose_comp.
+        unfold abs_colim_seq_to_abs_colim_succ_seq.
+        rhs snrapply (ap (fun x => cocone_postcompose x 
+            abs_colim_succ_seq_to_abs_colim_seq) 
+            (functor_colimit_commute _ _ _)^).
+        rhs snrapply cocone_precompose_postcompose.
+        unfold abs_colim_succ_seq_to_abs_colim_seq.
+        rhs snrapply (ap (fun x => cocone_precompose (seq_to_succ_seq A) x) 
+            (eisretr (cocone_postcompose col_succ_A) cocone_succ_seq_over_col)).
+        lhs snrapply (eisretr (cocone_postcompose col_A)).
+        reflexivity.
+    Defined.
+
+    Definition sec_abs_colim_seq_to_abs_succ_seq
+        : abs_colim_succ_seq_to_abs_colim_seq
+            o abs_colim_seq_to_abs_colim_succ_seq
+            = idmap.
+    Proof.
+        lhs snrapply cocone_precompose_seq_to_succ_seq_cocone_succ_seq_over_col_induces_comp^.
+        lhs snrapply (ap (fun x => cocone_postcompose_inv col_A x) 
+            cocone_succ_seq_over_col_is_ess_col).
+        exact (col_legs_induces_idmap).
+    Defined.
+
+        (** Hack while I think about this property *)
+
+        Definition ret_abs_colim_seq_to_abs_succ_seq
+            : abs_colim_seq_to_abs_colim_succ_seq 
+                o abs_colim_succ_seq_to_abs_colim_seq
+                = idmap.
+        Proof.
+        Admitted.
+
+    (** [abs_colim_seq_to_abs_colim_succ_seq] is an equivalence *)
+    
+    Definition equiv_abs_colim_seq_to_abs_colim_succ_seq
+        : IsEquiv abs_colim_seq_to_abs_colim_succ_seq.
+    Proof.
+        snrapply isequiv_adjointify.
+        - exact abs_colim_succ_seq_to_abs_colim_seq.
+        - exact (apD10 ret_abs_colim_seq_to_abs_succ_seq).
+        - exact (apD10 sec_abs_colim_seq_to_abs_succ_seq).
+    Defined.
+
+End Is_Equiv_colim_succ_seq_to_seq_map.
 
 (** Intersplitting is a pun of interleaving and splitting. 
     We will at first only assume that every other triangle
@@ -108,9 +195,10 @@ End Transfinite_composition.
 
 Section Intersplitting.
     Context `{Funext} {A B : Sequence} 
-        (transfinite_A : Type) (col_A : IsColimit A transfinite_A)
-        (transfinite_succ_A : Type) (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A)
-        (transfinite_B : Type) (col_B : IsColimit B transfinite_B)
+        {transfinite_A : Type} (col_A : IsColimit A transfinite_A)
+        {transfinite_succ_A : Type} 
+        (col_succ_A : IsColimit (succ_seq A) transfinite_succ_A)
+        {transfinite_B : Type} (col_B : IsColimit B transfinite_B)
         (d : DiagramMap A B) 
         (u : DiagramMap B (succ_seq A))
         (comm_triangle : seq_to_succ_seq A = diagram_comp u d).
@@ -118,16 +206,19 @@ Section Intersplitting.
     (** Given the data above, we show that the associated diagram in the
         colimit is also commutative.
 
+                  ≃
         col A_i -----> col A_i+1
             \           ^
              \         /
               \       /
                v     /
               col B_i
+
+        It follows that d is split-epi, and u is split-mono, as desired.
     *)
 
     Definition colimit_comm_triangle : 
-        (functor_colimit (seq_to_succ_seq A) col_A col_succ_A) 
+        abs_colim_seq_to_abs_colim_succ_seq col_A col_succ_A 
           = (functor_colimit u _ _) o (functor_colimit d _ _).
     Proof.
         rhs snrapply functoriality_functor_colimit.
@@ -138,12 +229,14 @@ Section Intersplitting.
 
 End Intersplitting.
 
-(** Now we will assume that every triangle is commutative. *)
+(** Now we will assume that every triangle is commutative.
+    By the 2-out-of-6 property, it follows that every map in
+    this diagram is an equivalence. *)
 
 Section Interleaving.
     Context {A B : Sequence} 
-        (transfiniteA : Type) (colA : IsColimit A transfiniteA)
-        (transfiniteB : Type) (colB : IsColimit B transfiniteB)
+        {transfiniteA : Type} (colA : IsColimit A transfiniteA)
+        {transfiniteB : Type} (colB : IsColimit B transfiniteB)
         (d : DiagramMap A B) 
         (u : DiagramMap B (succ_seq A))
         (tri1 : seq_to_succ_seq A = diagram_comp u d)

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -55,48 +55,46 @@ Section Sequence.
     Pp : Family A; (** Stored from previous step *)
     Qp : Family B; (** Stored from previous step *)
     concatQPp : Dot (flip R) Qp Pp; (** Stored from previous step *)
-    Q : Family B; (** Paths of length [t] *)
-    concatPQ : Dot R Pp Q; (** [t-1 -> t] *)
-    iotaQ (b : B) (x : Qp b) : Q b; (** [t-2 -> t] *)
-    P : Family A; (** Paths of length [t+1] *)
-    concatQP : Dot (flip R) Q P; (** [t -> t+1] *)
-    iotaP (a : A) (x : Pp a) : P a; (** [t-1 -> t+1] *)
-    concatQPQ (b : B) (a : A) (r : R a b) 
-      : (compose (concatPQ a b r) (concatQPp b a r)) == (iotaQ b);
-    concatPQP (a : A) (b : B) (r : R a b) 
-      : (compose (concatQP b a r) (concatPQ a b r)) == (iotaP a);
   }.
+
+  Definition Q (Z : zigzag_type) : Family B
+    := family_step (flip R) (concatQPp Z).
+
+  Definition concatPQ (Z : zigzag_type) : Dot R (Pp Z) (Q Z)
+    := dot_step (flip R) (concatQPp Z).
+
+  Definition iotaQ (Z : zigzag_type) : forall (b : B) (x : Qp Z b), Q Z b
+    := iota_step (flip R) (concatQPp Z).
+
+  Definition P (Z : zigzag_type) : Family A
+    := family_step R (concatPQ Z).
+
+  Definition concatQP (Z : zigzag_type) : Dot (flip R) (Q Z) (P Z)
+    := dot_step R (concatPQ Z).
+
+  Definition iotaP (Z : zigzag_type) : forall (a : A) (x : Pp Z a), P Z a
+    := iota_step R (concatPQ Z).
+
+  Definition concatQPQ (Z : zigzag_type)
+    : forall (b : B) (a : A) (r : R a b), (compose (concatPQ Z a b r) (concatQPp Z b a r)) == (iotaQ Z b)
+    := homotopy_step (flip R) (concatQPp Z).
+
+  Definition concatPQP (Z : zigzag_type)
+    : forall (a : A) (b : B) (r : R a b), (compose (concatQP Z b a r) (concatPQ Z a b r)) == (iotaP Z a)
+    := homotopy_step R (concatPQ Z).
 
   Definition zigzag_step : zigzag_type -> zigzag_type.
   Proof.
-    intros [_ _ _ Q0 _ _ P0 concatQP0 _ _ _];
-    pose (concatPQ := dot_step (flip R) concatQP0).
-    (* Naming them all seems to be necessary for Coq to not reorder goals. *)
-    snrapply (Build_zigzag_type P0 Q0 concatQP0).
-      - exact (family_step (flip R) concatQP0).
-      - exact concatPQ.
-      - exact (iota_step (flip R) concatQP0).
-      - exact (family_step R concatPQ).
-      - exact (dot_step R concatPQ).
-      - exact (iota_step R concatPQ).
-      - exact (homotopy_step (flip R) concatQP0).
-      - exact (homotopy_step R concatPQ).
+    intro Z.
+    exact (Build_zigzag_type (P Z) (Q Z) (concatQP Z)).
   Defined.
 
   Definition identity_zigzag_initial : zigzag_type.
   Proof.
     snrapply Build_zigzag_type.
-    - exact (fun a => Empty).
-    - exact (fun b => Empty).
-    - intros b a r q; destruct q.
-    - exact (fun b => Empty). (** Define [Q0 := Empty] *)
-    - intros a b r q; destruct q.
-    - intros b q; destruct q.
     - exact (fun a => a0 = a). (** Define [P0 := Id a0] *)
+    - exact (fun b => Empty). (** Define [Q0 := Empty] *)
     - intros b a r q; destruct q. (** Define [Q0 -> P_0] *)
-    - intros a q; destruct q. (** Define [P_-1 -> P0] *)
-    - intros; intro q; destruct q.
-    - intros; intro q; destruct q.
   Defined.
 
   Definition identity_zigzag : nat -> zigzag_type

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -16,21 +16,26 @@ Proof.
   - exact (P t).
 Defined.
 
-Record zigzag_type {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) : Type := {
-  Pp : A -> Type; (** Stored from previous step *)
-  Qp : B -> Type; (** Stored from previous step *)
-  concatQPp (a : A) (b : B) (r : R a b) (q : Qp b) : Pp a; (** Stored from previous step *)
-  Q : B -> Type; (** Paths of length t *)
-  concatPQ (a : A) (b : B) (r : R a b) (p : Pp a) : Q b; (** t-1 -> t *)
-  iotaQ (b : B) (x : Qp b) : Q b; (** t-2 -> t *)
-  P : A -> Type; (** Paths of length t+1 *)
-  concatQP (a : A) (b : B) (r : R a b) (q : Q b) : P a; (** t -> t+1 *)
-  iotaP (a : A) (x : Pp a) : P a; (** t-1 -> t+1 *)
-  concatQPQ (a : A) (b : B) (r : R a b) : (compose (concatPQ a b r) (concatQPp a b r)) == (iotaQ b);
-  concatPQP (a : A) (b : B) (r : R a b) : (compose (concatQP a b r) (concatPQ a b r)) == (iotaP a);
-}.
+Record zigzag_type {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) 
+  : Type := {
+    Pp : A -> Type; (** Stored from previous step *)
+    Qp : B -> Type; (** Stored from previous step *)
+    concatQPp (a : A) (b : B) (r : R a b) (q : Qp b) : Pp a; (** Stored from previous step *)
+    Q : B -> Type; (** Paths of length t *)
+    concatPQ (a : A) (b : B) (r : R a b) (p : Pp a) : Q b; (** t-1 -> t *)
+    iotaQ (b : B) (x : Qp b) : Q b; (** t-2 -> t *)
+    P : A -> Type; (** Paths of length t+1 *)
+    concatQP (a : A) (b : B) (r : R a b) (q : Q b) : P a; (** t -> t+1 *)
+    iotaP (a : A) (x : Pp a) : P a; (** t-1 -> t+1 *)
+    concatQPQ (a : A) (b : B) (r : R a b) 
+      : (compose (concatPQ a b r) (concatQPp a b r)) == (iotaQ b);
+    concatPQP (a : A) (b : B) (r : R a b) 
+      : (compose (concatQP a b r) (concatPQ a b r)) == (iotaP a);
+  }.
 
-Definition zigzag_step {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (z : zigzag_type R a0) : zigzag_type R a0.
+Definition zigzag_step {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (z : zigzag_type R a0) 
+  : zigzag_type R a0.
 Proof.
   destruct z.
   snrapply (let Pp:=_ in let Qp :=_ in let concatQPp :=_ in let Q:=_ in let concatPQ:=_ in let iotaQ:=_ in let P:=_ in let concatQP:=_ in let iotaP:=_ in let concatQPQ:=_ in let concatPQP:=_ in Build_zigzag_type A B R a0 Pp Qp concatQPp Q concatPQ iotaQ P concatQP iotaP concatQPQ concatPQP).
@@ -39,18 +44,17 @@ Proof.
   - exact concatQP0.
   - intros b. (** Constructing Q_t *)
     snrapply Pushout.
-    +exact (sig (fun a => prod (R a b) (Q0 b))).
+    + exact (sig (fun a => prod (R a b) (Q0 b))).
     + exact (Q0 b).
     + exact (sig (fun a => prod (R a b) (P0 a))).
     + intro x.
       exact (snd (pr2 x)).
     + intro a.
-      destruct a as [a p2].
-      destruct p2 as [r p].
+      destruct a as [a [r p]].
       exact (a ; (r , (concatQP0 a b r p))).
   - intros a b r p. (** Constructing P_{t-1} -> Q_t (concatPQ) *)
     snrapply pushr.
-exact (a ; (r , p)).
+    exact (a ; (r , p)).
   - intros b. (** Constructing Q_{t-1} -> Q_t *)
     exact pushl.
   - intro a. (** Constructing P_t *)
@@ -61,8 +65,7 @@ exact (a ; (r , p)).
     + intro x.
       exact (snd (pr2 x)).
     + intro b.
-      destruct b as [b p2].
-      destruct p2 as [r p].
+      destruct b as [b [r p]].
       exact (b ; (r , concatPQ a b r p)).
   - intros a b r p. (** Consructing Q_t -> P_t (concatQP) *)
     snrapply pushr.
@@ -121,7 +124,8 @@ exact (a ; (r , p)).
       exact (H q).
 Defined.
 
-Definition identity_zigzag_initial {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) : zigzag_type R a0.
+Definition identity_zigzag_initial {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) : zigzag_type R a0.
 Proof.
   snrapply (Build_zigzag_type A B R a0).
   - exact (fun a => Empty).
@@ -146,40 +150,74 @@ Proof.
     destruct q.
 Defined.
 
-Definition identity_zigzag {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (t : nat) : zigzag_type R a0 := nat_iter t (fun x => zigzag_step R a0 x) (identity_zigzag_initial R a0).
+Definition identity_zigzag {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (t : nat) 
+  : zigzag_type R a0 := 
+  nat_iter t (fun x => zigzag_step R a0 x) (identity_zigzag_initial R a0).
 
-Definition identity_zigzag_P {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (t : nat) : Type := (identity_zigzag R a0 t).(P R a0) a.
+Definition identity_zigzag_P {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (a : A) (t : nat) 
+  : Type := 
+  (identity_zigzag R a0 t).(P R a0) a.
 
-Definition identity_zigzag_iotaP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (t : nat) : (identity_zigzag_P R a0 a t) -> (identity_zigzag_P R a0 a (S t)) := (identity_zigzag R a0 (S t)).(iotaP R a0) a.
+Definition identity_zigzag_iotaP {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (a : A) (t : nat) 
+  : (identity_zigzag_P R a0 a t) -> (identity_zigzag_P R a0 a (S t)) := 
+  (identity_zigzag R a0 (S t)).(iotaP R a0) a.
 
-Definition identity_zigzag_P_seq {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) : Sequence.
+Definition identity_zigzag_P_seq {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (a : A) : Sequence.
 Proof.
   snrapply Build_Sequence.
   - exact (identity_zigzag_P R a0 a).
   - exact (identity_zigzag_iotaP R a0 a).
 Defined.
 
-Definition identity_zigzag_Q {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) (t : nat) : Type := (identity_zigzag R a0 t).(Q R a0) b.
+Definition identity_zigzag_Q {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (b : B) (t : nat) : Type := 
+  (identity_zigzag R a0 t).(Q R a0) b.
 
-Definition identity_zigzag_iotaQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) (t : nat) : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_Q R a0 b (S t)) := (identity_zigzag R a0 (S t)).(iotaQ R a0) b.
+Definition identity_zigzag_iotaQ {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (b : B) (t : nat) 
+  : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_Q R a0 b (S t)) := 
+  (identity_zigzag R a0 (S t)).(iotaQ R a0) b.
 
-Definition identity_zigzag_Q_seq {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) : Sequence.
+Definition identity_zigzag_Q_seq {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (b : B) : Sequence.
 Proof.
   snrapply Build_Sequence.
   - exact (identity_zigzag_Q R a0 b).
   - exact (identity_zigzag_iotaQ R a0 b).
 Defined.
 
-Definition identity_zigzag_concatQP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_P R a0 a t) := (identity_zigzag R a0 t).(concatQP R a0) a b r.
+Definition identity_zigzag_concatQP {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) 
+  : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_P R a0 a t) := 
+  (identity_zigzag R a0 t).(concatQP R a0) a b r.
 
 
-Definition identity_zigzag_concatPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (identity_zigzag_P R a0 a t) -> (identity_zigzag_Q R a0 b (S t)) := (identity_zigzag R a0 (S t)).(concatPQ R a0) a b r.
+Definition identity_zigzag_concatPQ {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : 
+  (identity_zigzag_P R a0 a t) -> (identity_zigzag_Q R a0 b (S t)) := 
+  (identity_zigzag R a0 (S t)).(concatPQ R a0) a b r.
 
-Definition identity_zigzag_concatQPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (compose (identity_zigzag_concatPQ R a0 a b r t) (identity_zigzag_concatQP R a0 a b r t)) == (identity_zigzag_iotaQ R a0 b t) := (identity_zigzag R a0 (S t)).(concatQPQ R a0) a b r.
+Definition identity_zigzag_concatQPQ {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : 
+  (compose (identity_zigzag_concatPQ R a0 a b r t) 
+    (identity_zigzag_concatQP R a0 a b r t)) 
+  == (identity_zigzag_iotaQ R a0 b t) := 
+  (identity_zigzag R a0 (S t)).(concatQPQ R a0) a b r.
 
-Definition identity_zigzag_concatPQP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (compose (identity_zigzag_concatQP R a0 a b r (S t)) (identity_zigzag_concatPQ R a0 a b r t)) == (identity_zigzag_iotaP R a0 a t) := (identity_zigzag R a0 (S t)).(concatPQP R a0) a b r.
+Definition identity_zigzag_concatPQP {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : 
+  (compose (identity_zigzag_concatQP R a0 a b r (S t)) 
+    (identity_zigzag_concatPQ R a0 a b r t)) 
+  == (identity_zigzag_iotaP R a0 a t) := 
+  (identity_zigzag R a0 (S t)).(concatPQP R a0) a b r.
 
-Definition identity_zigzag_seq_concatQP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : DiagramMap (identity_zigzag_Q_seq R a0 b) (identity_zigzag_P_seq R a0 a).
+Definition identity_zigzag_seq_concatQP {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (a : A) (b : B) (r : R a b) : 
+  DiagramMap (identity_zigzag_Q_seq R a0 b) (identity_zigzag_P_seq R a0 a).
 Proof.
   snrapply Build_DiagramMap.
   - intro t.
@@ -211,11 +249,17 @@ Proof.
       exact (identity_zigzag_concatPQP R a0 a b r t _).
 Defined.
 
-Definition identity_zigzag_Pinf {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) : Type := Colimit (identity_zigzag_P_seq R a0 a).
+Definition identity_zigzag_Pinf {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (a : A) : Type := 
+  Colimit (identity_zigzag_P_seq R a0 a).
 
-Definition identity_zigzag_Qinf {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) : Type := Colimit (identity_zigzag_Q_seq R a0 b).
+Definition identity_zigzag_Qinf {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (b : B) : Type := 
+  Colimit (identity_zigzag_Q_seq R a0 b).
 
-Definition identity_zigzag_Pswap {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (t : nat) : (identity_zigzag_P R a0 a t) <~> (identity_zigzag_P R a a0 t).
+Definition identity_zigzag_Pswap {A : Type} {B : Type} (R : A -> B -> Type) 
+  (a0 : A) (a : A) (t : nat) 
+  : (identity_zigzag_P R a0 a t) <~> (identity_zigzag_P R a a0 t).
 Proof.
   induction t.
   + simpl.
@@ -225,18 +269,30 @@ Proof.
     snrapply Build_Equiv.
 Admitted.
 
-Definition identity_zigzag_concatQPinf `{Funext} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : (identity_zigzag_Qinf R a0 b) -> (identity_zigzag_Pinf R a0 a) := functor_colimit (identity_zigzag_seq_concatQP R a0 a b r) _ _.
+Definition identity_zigzag_concatQPinf `{Funext} {A : Type} {B : Type} 
+  (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) 
+  : (identity_zigzag_Qinf R a0 b) -> (identity_zigzag_Pinf R a0 a) := 
+  functor_colimit (identity_zigzag_seq_concatQP R a0 a b r) _ _.
 
-Definition identity_zigzag_concatPQinf `{Funext} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : (identity_zigzag_Pinf R a0 a) -> (identity_zigzag_Qinf R a0 b) := (colim_succ_seq_to_colim_seq _) o (functor_colimit (identity_zigzag_seq_concatPQ R a0 a b r) _ _ ).
+Definition identity_zigzag_concatPQinf `{Funext} {A : Type} {B : Type} 
+  (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) 
+  : (identity_zigzag_Pinf R a0 a) -> (identity_zigzag_Qinf R a0 b) := 
+  (colim_succ_seq_to_colim_seq _) 
+  o (functor_colimit (identity_zigzag_seq_concatPQ R a0 a b r) _ _ ).
 
 Section Death.
-  Context `{Funext} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b).
+  Context `{Funext} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) 
+    (a : A) (b : B) (r : R a b).
 
   Check (identity_zigzag_concatPQinf).
 
 End Death.
 
-Definition identity_zigzag_concatinf_retr `{Univalence} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : (identity_zigzag_concatPQinf R a0 a b r) o (identity_zigzag_concatQPinf R a0 a b r) == idmap.
+Definition identity_zigzag_concatinf_retr `{Univalence} {A : Type} {B : Type} 
+  (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) 
+  : (identity_zigzag_concatPQinf R a0 a b r) 
+    o (identity_zigzag_concatQPinf R a0 a b r) 
+    == idmap.
 Proof.
   snrapply Colimit_ind.
   - simpl.
@@ -252,29 +308,39 @@ Proof.
     admit.
 Admitted.
 
-Definition identity_zigzag_concatinf_sec `{Univalence} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : (identity_zigzag_concatQPinf R a0 a b r) o (identity_zigzag_concatPQinf R a0 a b r) == idmap.
+Definition identity_zigzag_concatinf_sec `{Univalence} {A : Type} {B : Type}
+  (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) 
+  : (identity_zigzag_concatQPinf R a0 a b r) 
+    o (identity_zigzag_concatPQinf R a0 a b r) 
+    == idmap.
 Proof.
 Admitted.
 
-Definition isequiv_identity_zigzag_concatinf `{Univalence} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : IsEquiv (identity_zigzag_concatPQinf R a0 a b r).
+Definition isequiv_identity_zigzag_concatinf `{Univalence} {A : Type} 
+  {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) 
+  : IsEquiv (identity_zigzag_concatPQinf R a0 a b r).
 Proof.
   snrapply isequiv_adjointify.
   2: exact (identity_zigzag_concatinf_retr R a0 a b r).
   exact (identity_zigzag_concatinf_sec R a0 a b r).
 Defined.
 
-Definition relation_type {A : Type} {B : Type} (R : A -> B -> Type) : Type := { a : A | { b : B | R a b}}.
+Definition relation_type {A : Type} {B : Type} (R : A -> B -> Type) 
+  : Type := { a : A | { b : B | R a b}}.
 
-Definition relation_pr1 {A: Type} {B : Type} (R : A -> B -> Type) : (relation_type R) -> A := pr1.
+Definition relation_pr1 {A: Type} {B : Type} (R : A -> B -> Type) 
+  : (relation_type R) -> A := pr1.
 
-Definition relation_pr2 {A: Type} {B : Type} (R : A -> B -> Type) : (relation_type R) -> B.
+Definition relation_pr2 {A: Type} {B : Type} (R : A -> B -> Type) 
+  : (relation_type R) -> B.
 Proof.
   intro a.
   destruct a as [a b].
   exact (pr1 b).
 Defined.
 
-Definition relation_flip {A : Type} {B : Type} (R : A -> B -> Type) : forall (b : B)  (a : A), Type.
+Definition relation_flip {A : Type} {B : Type} (R : A -> B -> Type) 
+  : forall (b : B)  (a : A), Type.
 Proof.
   intros b a.
   exact (R a b).
@@ -287,16 +353,15 @@ Proof.
   - exact A.
   - exact B.
   - intro a.
-    destruct a as [a b].
-    destruct b as [b r].
+    destruct a as [a _].
     exact a.
   - intro a.
-    destruct a as [a b].
-    destruct b as [b r].
+    destruct a as [a [b r]].
     exact b.
 Defined.
 
-Definition identity_zigzag_family `{Univalence} {A : Type} {B : Type} (R : A -> B -> Type) : (Pushout_relation R) -> (Pushout_relation R) -> Type.
+Definition identity_zigzag_family `{Univalence} {A : Type} {B : Type} 
+  (R : A -> B -> Type) : (Pushout_relation R) -> (Pushout_relation R) -> Type.
 Proof.
   snrapply Pushout_rec.
   - intro x.
@@ -306,8 +371,7 @@ Proof.
     + intro y.
       exact (identity_zigzag_Qinf R x y).
     + intro r.
-      destruct r as [a r].
-      destruct r as [b r].
+      destruct r as [a [b r]].
       snrapply path_universe_uncurried.
       snrapply Build_Equiv.
       * exact (identity_zigzag_concatPQinf R x a b r).
@@ -320,16 +384,14 @@ Proof.
     + intro y.
       exact (identity_zigzag_Pinf R' x y).
     + intro r.
-      destruct r as [a r].
-      destruct r as [b r].
+      destruct r as [a [b r]].
       snrapply path_universe_uncurried.
       symmetry.
       snrapply Build_Equiv.
       * exact (identity_zigzag_concatPQinf R' x b a r).
       * exact (isequiv_identity_zigzag_concatinf R' x b a r).
   - intro r.
-    destruct r as [a r].
-    destruct r as [b r].
+    destruct r as [a [b r]].
     snrapply path_forall.
     snrapply Pushout_ind.
     + intro a'.

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -173,3 +173,5 @@ Definition identity_zigzag_concatQPinf
 Definition identity_zigzag_concatPQinf 
   : (identity_zigzag_Pinf a) -> (identity_zigzag_Qinf b)
   := (colim_succ_seq_to_colim_seq _) o (functor_colimit (identity_zigzag_concatPQ_seq R a0 r) _ _ ).
+
+End Colimit.

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -1,6 +1,11 @@
 Require Import Basics.
 Require Import Colimits.Pushout.
 Require Import Spaces.Nat.
+Require Import Basics.Tactics.
+Require Import Diagrams.Sequence.
+Require Import WildCat.
+
+Set Implicit Arguments.
 
 Definition pred_type_or_empty (P : nat -> Type) (t : nat) : Type.
 Proof.
@@ -19,35 +24,125 @@ Record zigzag_type {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) : Type :=
   P : A -> Type; (** Paths of length t+1 *)
   concatQP (a : A) (b : B) (r : R a b) (q : Q b) : P a; (** t -> t+1 *)
   iotaP (a : A) (x : Pp a) : P a; (** t-1 -> t+1 *)
+  concatQPQ (a : A) (b : B) (r : R a b) : (compose (concatPQ r) (concatQPp r)) == (iotaQ (b := b));
+  concatPQP (a : A) (b : B) (r : R a b) : (compose (concatQP r) (concatPQ r)) == (iotaP (a := a));
 }.
 
-Definition identity_zigzag {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (t : nat) : zigzag_type R a0.
+Definition zigzag_step {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (z : zigzag_type R a0) : zigzag_type R a0.
 Proof.
+  destruct z.
+  snrapply (let Pp:=_ in let Qp :=_ in let concatQPp :=_ in let Q:=_ in let concatPQ:=_ in let iotaQ:=_ in let P:=_ in let concatQP:=_ in let iotaP:=_ in let concatQPQ:=_ in let concatPQP:=_ in Build_zigzag_type R a0 Pp Qp concatQPp Q concatPQ iotaQ P concatQP iotaP concatQPQ concatPQP).
+  - exact P0.
+  - exact Q0.
+  - exact concatQP0.
+  - intros b. (** Constructing Q_t *)
+    snrapply Pushout.
+    +exact (sig (fun a => prod (R a b) (Q0 b))).
+    + exact (Q0 b).
+    + exact (sig (fun a => prod (R a b) (P0 a))).
+    + intro x.
+      exact (snd (pr2 x)).
+    + intro a.
+      destruct a as [a p2].
+      destruct p2 as [r p].
+      exact (a ; (r , (concatQP0 a b r p))).
+  - intros a b r p. (** Constructing P_{t-1} -> Q_t (concatPQ) *)
+    snrapply pushr.
+    exact (a ; (r , p)).
+  - intros b. (** Constructing Q_{t-1} -> Q_t *)
+    exact pushl.
+  - intro a. (** Constructing P_t *)
+    snrapply Pushout.
+    + exact (sig (fun b => prod (R a b) (P0 a))).
+    + exact (P0 a).
+    + exact (sig (fun b => prod (R a b) (Q b))).
+    + intro x.
+      exact (snd (pr2 x)).
+    + intro b.
+      destruct b as [b p2].
+      destruct p2 as [r p].
+      exact (b ; (r , concatPQ a b r p)).
+  - intros a b r p. (** Consructin Q_t -> P_t (concatQP) *)
+    snrapply pushr.
+    exact (b ; (r , p)).
+  - intros a. (** Constructing P_{t-1} -> P_t *)
+    exact pushl.
+  - intros a b r.
+    transparent assert (incl : ((Qp b) -> (sig (fun a' => prod (R a' b) (Qp b))))). {
+      intro q'.
+      exact (a ; (r , q')).
+    }
+    transparent assert (proj : ((sig (fun a' => prod (R a' b) (Qp b))) -> (Qp b))). {
+      intro x.
+      destruct x.
+      destruct proj2.
+      exact snd.
+    }
+    transparent assert (H : (proj o incl == idmap)). {
+      intro x.
+      reflexivity.
+    }
+    transitivity ((iotaQ b) o proj o incl).
+    + admit.
+    + intro q.
+      apply ap.
+      exact 
+
+
+
+
+Definition identity_zigzag_initial {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) : zigzag_type R a0.
+Proof.
+  snrapply (Build_zigzag_type R a0).
+  - exact (fun a => Empty).
+  - exact (fun b => Empty).
+  - intros a b r q.
+    destruct q.
+  - exact (fun b => Empty). (** Define Q_0 := Empty *)
+  - intros a b r q. (** Define P_{-1} -> Q_0 *)
+    destruct q.
+  - intros b q. (** Define Q_{-1} -> Q_0 *)
+    destruct q.
+  - exact (fun a => a0 = a). (** Define P_0 := Id a0 *)
+  - intros a b r q. (** Define Q_0 -> P_0 *)
+    destruct q.
+  - intros a p. (** Define P_{-1} -> P_0 *)
+    destruct p.
+Defined.
+
+Definition identity_zigzag {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (t : nat) : zigzag_type R a0 := nat_iter t (fun x => zigzag_step x) (identity_zigzag_initial R a0).
+
+Definition identity_zigzag_P {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (t : nat) : Type := (identity_zigzag R a0 t).(P) a.
+
+Definition identity_zigzag_iotaP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (t : nat) : (identity_zigzag_P R a0 a t) -> (identity_zigzag_P R a0 a (S t)) := (identity_zigzag R a0 (S t)).(iotaP) a.
+
+Definition identity_zigzag_P_seq {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) : Sequence.
+Proof.
+  snrapply Build_Sequence.
+  - exact (identity_zigzag_P R a0 a).
+  - exact (identity_zigzag_iotaP R a0 a).
+Defined.
+
+Definition identity_zigzag_Q {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) (t : nat) : Type := (identity_zigzag R a0 t).(Q) b.
+
+Definition identity_zigzag_iotaQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) (t : nat) : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_Q R a0 b (S t)) := (identity_zigzag R a0 (S t)).(iotaQ) b.
+
+Definition identity_zigzag_Q_seq {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) : Sequence.
+Proof.
+  snrapply Build_Sequence.
+  - exact (identity_zigzag_Q R a0 b).
+  - exact (identity_zigzag_iotaQ R a0 b).
+Defined.
+
+Definition identity_zigzag_concatQP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_P R a0 a t) := (identity_zigzag R a0 t).(concatQP) a b r.
+
+
+Definition identity_zigzag_concatPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (identity_zigzag_P R a0 a t) -> (identity_zigzag_Q R a0 b (S t)) := (identity_zigzag R a0 (S t)).(concatPQ) a b r.
+
+Definition identity_zigzag_concatQPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (compose (identity_zigzag_concatPQ R a0 a b r t) (identity_zigzag_concatQP R a0 a b r t)) == (identity_zigzag_iotaQ R a0 b t).
+Proof.
+  intro p.
   induction t.
-  - snrapply Build_zigzag_type.
-    + exact (fun a => Empty).
-    + exact (fun b => Empty).
-    + intros a b r e.
-      destruct e.
-    + exact (fun b => Empty).
-    + intros a b r e.
-      destruct e.
-    + intros b e.
-      destruct e.
-    + exact (fun a => a0 = a).
-    + intros a b r e.
-      destruct e.
-    + intros a e.
-      destruct e.
-  - destruct IHt.
-    snrapply Build_zigzag_type.
-    + exact P0.
-    + exact Q0.
-    + exact concatQP0.
-    + intros b.
-      snrapply Pushout.
-      * exact (sig (fun a => prod (R a b) (Q0 b))).
-      * exact (Q0 b).
-      * exact (sig (fun a => prod (R a b) (P0 a))).
-      * intro x.
-        exact (snd (pr2 x)).
+  - destruct p.
+  - 
+

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -106,44 +106,44 @@ Section Sequence.
   Proof.
     intro a.
     snrapply Build_Sequence.
-    - intro n; exact ((identity_zigzag n).(P) a).
-    - intro n; exact ((identity_zigzag (S n)).(iotaP) a).
+    - intro n; exact (P (identity_zigzag n) a).
+    - intro n; exact (iotaP (identity_zigzag (S n)) a).
   Defined.
 
   Definition identity_zigzag_Q_seq : B -> Sequence.
   Proof.
     intro b.
     snrapply Build_Sequence.
-    - intro n; exact ((identity_zigzag n).(Q) b).
-    - intro n; exact ((identity_zigzag (S n)).(iotaQ) b).
+    - intro n; exact (Q (identity_zigzag n) b).
+    - intro n; exact (iotaQ (identity_zigzag (S n)) b).
   Defined.
 
   Definition identity_zigzag_concatPQ_seq {a : A} {b : B} (r : R a b) 
     : DiagramMap (identity_zigzag_P_seq a) (succ_seq (identity_zigzag_Q_seq b)).
   Proof.
     snrapply Build_DiagramMap.
-    - intro n; exact ((identity_zigzag (S n)).(concatPQ) a b r).
+    - intro n; exact (concatPQ (identity_zigzag (S n)) a b r).
     - intros n m g x.
       destruct g.
-      transitivity ((identity_zigzag (S (S n))).(concatPQ) a b r ((identity_zigzag (S n)).(concatQP) b a r ((identity_zigzag (S n)).(concatPQ) a b r x))).
+      transitivity (concatPQ (identity_zigzag (S (S n))) a b r (concatQP (identity_zigzag (S n)) b a r (concatPQ (identity_zigzag (S n)) a b r x))).
       + symmetry.
-        exact ((identity_zigzag (S (S n))).(concatQPQ) b a r _).
+        exact (concatQPQ (identity_zigzag (S (S n))) b a r _).
       + apply ap.
-        exact ((identity_zigzag (S n)).(concatPQP) a b r _).
+        exact (concatPQP (identity_zigzag (S n)) a b r _).
   Defined.
 
   Definition identity_zigzag_concatQP_seq {a : A} {b : B} (r : R a b) 
     : DiagramMap (identity_zigzag_Q_seq b) (identity_zigzag_P_seq a).
   Proof.
     snrapply Build_DiagramMap.
-    - intro n; exact ((identity_zigzag n).(concatQP) b a r).
+    - intro n; exact (concatQP (identity_zigzag n) b a r).
     - intros n m g x.
       destruct g.
-      transitivity ((identity_zigzag (S n)).(concatQP) b a r ((identity_zigzag (S n)).(concatPQ) a b r ((identity_zigzag n).(concatQP) b a r x))).
+      transitivity (concatQP (identity_zigzag (S n)) b a r (concatPQ (identity_zigzag (S n)) a b r (concatQP (identity_zigzag n) b a r x))).
       + symmetry.
-        exact ((identity_zigzag (S n)).(concatPQP) a b r _).
+        exact (concatPQP (identity_zigzag (S n)) a b r _).
       + apply ap.
-        exact ((identity_zigzag (S n)).(concatQPQ) b a r _).
+        exact (concatQPQ (identity_zigzag (S n)) b a r _).
   Defined.
 
 End Sequence.

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -9,11 +9,7 @@ Require Import Colimits.Sequential.
 Require Import Diagram.
 Require Import Types.
 
-(** * Work towards characterizing the path types in a pushout of a span [R : A -> B -> Type]. *)
-
-(** The goal here is to work in half-steps, so that each construction only happens once. *)
-
-(** [C] will be used to denote a type that might be [A] or [B].  We think of a term of [Family C] as being the family [fun c => a0 squiggle_t c]. *)
+(** * Work towards characterizing the path types in a pushout of a span [R : A -> B -> Type]. The goal here is to work in half-steps, so that each construction only happens once. [C] will be used to denote a type that might be [A] or [B].  We think of a term of [Family C] as being the family [fun c => a0 squiggle_t c]. *)
 Definition Family (C : Type) := C -> Type.
 
 (** Here [P a] should be thought of as [a_0 squiggle_t a] and [Q b] as [a_0 squiggle_{t+1} b].  This describes the type of the "dot" operation [- ._t -]. This will also be used with [A] and [B] swapped and [R] flipped. *)
@@ -51,22 +47,20 @@ Section InductiveStep.
     := fun a b r p => inverse (pglue ((b ; r) , p)).
 End InductiveStep.
 
-Definition Dot {A B : Type} (R : A -> B -> Type) (P : Family A) (Q : Family B)
-  := forall (a : A) (b : B) (r : R a b) (p : P a), Q b.
 Section Sequence.
   Context {A B : Type} (R : A -> B -> Type) (a0 : A).
 
-  (** Use a record type for a full step to avoid the interleaved sequence and `flip R`. *)
+  (** Use a record type for a full step to avoid the interleaved sequence and [flip R]. *)
   Record zigzag_type : Type := {
     Pp : Family A; (** Stored from previous step *)
     Qp : Family B; (** Stored from previous step *)
     concatQPp : Dot (flip R) Qp Pp; (** Stored from previous step *)
-    Q : Family B; (** Paths of length t *)
-    concatPQ : Dot R Pp Q; (** t-1 -> t *)
-    iotaQ (b : B) (x : Qp b) : Q b; (** t-2 -> t *)
-    P : Family A; (** Paths of length t+1 *)
-    concatQP : Dot (flip R) Q P; (** t -> t+1 *)
-    iotaP (a : A) (x : Pp a) : P a; (** t-1 -> t+1 *)
+    Q : Family B; (** Paths of length [t] *)
+    concatPQ : Dot R Pp Q; (** [t-1 -> t] *)
+    iotaQ (b : B) (x : Qp b) : Q b; (** [t-2 -> t] *)
+    P : Family A; (** Paths of length [t+1] *)
+    concatQP : Dot (flip R) Q P; (** [t -> t+1] *)
+    iotaP (a : A) (x : Pp a) : P a; (** [t-1 -> t+1] *)
     concatQPQ (b : B) (a : A) (r : R a b) 
       : (compose (concatPQ a b r) (concatQPp b a r)) == (iotaQ b);
     concatPQP (a : A) (b : B) (r : R a b) 
@@ -95,12 +89,12 @@ Section Sequence.
     - exact (fun a => Empty).
     - exact (fun b => Empty).
     - intros b a r q; destruct q.
-    - exact (fun b => Empty). (** Define Q0 := Empty *)
+    - exact (fun b => Empty). (** Define [Q0 := Empty] *)
     - intros a b r q; destruct q.
     - intros b q; destruct q.
-    - exact (fun a => a0 = a). (** Define P0 := Id a0 *)
-    - intros b a r q; destruct q. (** Define Q0 -> P_0 *)
-    - intros a q; destruct q. (** Define P_{-1} -> P0 *)
+    - exact (fun a => a0 = a). (** Define [P0 := Id a0] *)
+    - intros b a r q; destruct q. (** Define [Q0 -> P_0] *)
+    - intros a q; destruct q. (** Define [P_-1 -> P0] *)
     - intros; intro q; destruct q.
     - intros; intro q; destruct q.
   Defined.

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -49,8 +49,7 @@ Proof.
     + exact (sig (fun a => prod (R a b) (P0 a))).
     + intro x.
       exact (snd (pr2 x)).
-    + intro a.
-      destruct a as [a [r p]].
+    + intros [a [r p]].
       exact (a ; (r , (concatQP0 a b r p))).
   - intros a b r p. (** Constructing P_{t-1} -> Q_t (concatPQ) *)
     snrapply pushr.
@@ -64,8 +63,7 @@ Proof.
     + exact (sig (fun b => prod (R a b) (Q b))).
     + intro x.
       exact (snd (pr2 x)).
-    + intro b.
-      destruct b as [b [r p]].
+    + intros [b [r p]].
       exact (b ; (r , concatPQ a b r p)).
   - intros a b r p. (** Consructing Q_t -> P_t (concatQP) *)
     snrapply pushr.
@@ -128,26 +126,16 @@ Definition identity_zigzag_initial {A : Type} {B : Type} (R : A -> B -> Type)
   (a0 : A) : zigzag_type R a0.
 Proof.
   snrapply (Build_zigzag_type A B R a0).
-  - exact (fun a => Empty).
-  - exact (fun b => Empty).
-  - intros a b r q.
-    destruct q.
-  - exact (fun b => Empty). (** Define Q_0 := Empty *)
-  - intros a b r q. (** Define P_{-1} -> Q_0 *)
-    destruct q.
-  - intros b q. (** Define Q_{-1} -> Q_0 *)
-    destruct q.
-  - exact (fun a => a0 = a). (** Define P_0 := Id a0 *)
-  - intros a b r q. (** Define Q_0 -> P_0 *)
-    destruct q.
-  - intros a p. (** Define P_{-1} -> P_0 *)
-    destruct p.
-  - intros.
-    intro q.
-    destruct q.
-  - intros.
-    intro q.
-    destruct q.
+  1, 2, 4: exact (fun b => Empty). (** Define Q_0 := Empty *)
+  4: exact (fun a => a0 = a). (** Define P_0 := Id a0 *)
+  all: intros.
+  - destruct q.
+  - destruct p. (** Define P_{-1} -> Q_0 *)
+  - destruct x. (** Define Q_{-1} -> Q_0 *)
+  - destruct q. (** Define Q_0 -> P_0 *)
+  - destruct x. (** Define P_{-1} -> P_0 *)
+  - intros [].
+  - intros [].
 Defined.
 
 Definition identity_zigzag {A : Type} {B : Type} (R : A -> B -> Type) 
@@ -197,13 +185,13 @@ Definition identity_zigzag_concatQP {A : Type} {B : Type} (R : A -> B -> Type)
 
 
 Definition identity_zigzag_concatPQ {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : 
-  (identity_zigzag_P R a0 a t) -> (identity_zigzag_Q R a0 b (S t)) := 
+  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) 
+  : (identity_zigzag_P R a0 a t) -> (identity_zigzag_Q R a0 b (S t)) := 
   (identity_zigzag R a0 (S t)).(concatPQ R a0) a b r.
 
 Definition identity_zigzag_concatQPQ {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : 
-  (compose (identity_zigzag_concatPQ R a0 a b r t) 
+  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) 
+  : (compose (identity_zigzag_concatPQ R a0 a b r t) 
     (identity_zigzag_concatQP R a0 a b r t)) 
   == (identity_zigzag_iotaQ R a0 b t) := 
   (identity_zigzag R a0 (S t)).(concatQPQ R a0) a b r.
@@ -216,8 +204,8 @@ Definition identity_zigzag_concatPQP {A : Type} {B : Type} (R : A -> B -> Type)
   (identity_zigzag R a0 (S t)).(concatPQP R a0) a b r.
 
 Definition identity_zigzag_seq_concatQP {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) (b : B) (r : R a b) : 
-  DiagramMap (identity_zigzag_Q_seq R a0 b) (identity_zigzag_P_seq R a0 a).
+  (a0 : A) (a : A) (b : B) (r : R a b) 
+  : DiagramMap (identity_zigzag_Q_seq R a0 b) (identity_zigzag_P_seq R a0 a).
 Proof.
   snrapply Build_DiagramMap.
   - intro t.
@@ -232,12 +220,12 @@ Proof.
       exact (identity_zigzag_concatQPQ R a0 a b r t _).
 Defined.
 
-Definition identity_zigzag_seq_concatPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : DiagramMap (identity_zigzag_P_seq R a0 a) (succ_seq (identity_zigzag_Q_seq R a0 b)).
+Definition identity_zigzag_seq_concatPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) 
+  (a : A) (b : B) (r : R a b) 
+  : DiagramMap (identity_zigzag_P_seq R a0 a) (succ_seq (identity_zigzag_Q_seq R a0 b)).
 Proof.
   snrapply Build_DiagramMap.
   - intro t.
-    simpl.
-    Compute (Graph.graph0 sequence_graph).
     exact (identity_zigzag_concatPQ R a0 a b r t).
   - intros t p q x.
     destruct q.
@@ -277,7 +265,7 @@ Definition identity_zigzag_concatQPinf `{Funext} {A : Type} {B : Type}
 Definition identity_zigzag_concatPQinf `{Funext} {A : Type} {B : Type} 
   (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) 
   : (identity_zigzag_Pinf R a0 a) -> (identity_zigzag_Qinf R a0 b) := 
-  (colim_succ_seq_to_colim_seq _) 
+  (colim_succ_seq_to_colim_seq _)
   o (functor_colimit (identity_zigzag_seq_concatPQ R a0 a b r) _ _ ).
 
 Section Death.
@@ -297,14 +285,17 @@ Proof.
   snrapply Colimit_ind.
   - simpl.
     intros t p.
-    transitivity (inj (identity_zigzag_Q_seq R a0 b) (S t) (identity_zigzag_concatPQ R a0 a b r t (identity_zigzag_concatQP R a0 a b r t p))).
+    transitivity (inj (identity_zigzag_Q_seq R a0 b) (S t) 
+      (identity_zigzag_concatPQ R a0 a b r t (identity_zigzag_concatQP R a0 a b r t p))).
     + reflexivity.
-    + transitivity (inj (identity_zigzag_Q_seq R a0 b) (S t) (identity_zigzag_iotaQ R a0 b t p)).
+    + transitivity (inj (identity_zigzag_Q_seq R a0 b) (S t) 
+      (identity_zigzag_iotaQ R a0 b t p)).
       * apply ap.
         exact (identity_zigzag_concatQPQ R a0 a b r t p).
       * apply (glue (identity_zigzag_Q_seq R a0 b)).
   - intros t n q p.
     destruct q.
+    simpl.
     admit.
 Admitted.
 

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -1,0 +1,53 @@
+Require Import Basics.
+Require Import Colimits.Pushout.
+Require Import Spaces.Nat.
+
+Definition pred_type_or_empty (P : nat -> Type) (t : nat) : Type.
+Proof.
+  induction t.
+  - exact Empty.
+  - exact (P t).
+Defined.
+
+Record zigzag_type {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) : Type := {
+  Pp : A -> Type; (** Stored from previous step *)
+  Qp : B -> Type; (** Stored from previous step *)
+  concatQPp (a : A) (b : B) (r : R a b) (q : Qp b) : Pp a; (** Stored from previous step *)
+  Q : B -> Type; (** Paths of length t *)
+  concatPQ (a : A) (b : B) (r : R a b) (p : Pp a) : Q b; (** t-1 -> t *)
+  iotaQ (b : B) (x : Qp b) : Q b; (** t-2 -> t *)
+  P : A -> Type; (** Paths of length t+1 *)
+  concatQP (a : A) (b : B) (r : R a b) (q : Q b) : P a; (** t -> t+1 *)
+  iotaP (a : A) (x : Pp a) : P a; (** t-1 -> t+1 *)
+}.
+
+Definition identity_zigzag {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (t : nat) : zigzag_type R a0.
+Proof.
+  induction t.
+  - snrapply Build_zigzag_type.
+    + exact (fun a => Empty).
+    + exact (fun b => Empty).
+    + intros a b r e.
+      destruct e.
+    + exact (fun b => Empty).
+    + intros a b r e.
+      destruct e.
+    + intros b e.
+      destruct e.
+    + exact (fun a => a0 = a).
+    + intros a b r e.
+      destruct e.
+    + intros a e.
+      destruct e.
+  - destruct IHt.
+    snrapply Build_zigzag_type.
+    + exact P0.
+    + exact Q0.
+    + exact concatQP0.
+    + intros b.
+      snrapply Pushout.
+      * exact (sig (fun a => prod (R a b) (Q0 b))).
+      * exact (Q0 b).
+      * exact (sig (fun a => prod (R a b) (P0 a))).
+      * intro x.
+        exact (snd (pr2 x)).

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -51,10 +51,11 @@ Section Sequence.
   Context {A B : Type} (R : A -> B -> Type) (a0 : A).
 
   (** Use a record type for a full step to avoid the interleaved sequence and [flip R]. *)
+  (* jdc: rename to Zig? *)
   Record zigzag_type : Type := {
-    Pp : Family A; (** Stored from previous step *)
-    Qp : Family B; (** Stored from previous step *)
-    concatQPp : Dot (flip R) Qp Pp; (** Stored from previous step *)
+    Pp : Family A;
+    Qp : Family B;
+    concatQPp : Dot (flip R) Qp Pp;
   }.
 
   Definition Q (Z : zigzag_type) : Family B

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -215,6 +215,16 @@ Definition identity_zigzag_Pinf {A : Type} {B : Type} (R : A -> B -> Type) (a0 :
 
 Definition identity_zigzag_Qinf {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) : Type := Colimit (identity_zigzag_Q_seq R a0 b).
 
+Definition identity_zigzag_Pswap {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (t : nat) : (identity_zigzag_P R a0 a t) <~> (identity_zigzag_P R a a0 t).
+Proof.
+  induction t.
+  + simpl.
+    snrapply Build_Equiv.
+    2: exact (isequiv_path_inverse a0 a).
+  + simpl.
+    snrapply Build_Equiv.
+Admitted.
+
 Definition identity_zigzag_concatQPinf `{Funext} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : (identity_zigzag_Qinf R a0 b) -> (identity_zigzag_Pinf R a0 a) := functor_colimit (identity_zigzag_seq_concatQP R a0 a b r) _ _.
 
 Definition identity_zigzag_concatPQinf `{Funext} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : (identity_zigzag_Pinf R a0 a) -> (identity_zigzag_Qinf R a0 b) := (colim_succ_seq_to_colim_seq _) o (functor_colimit (identity_zigzag_seq_concatPQ R a0 a b r) _ _ ).
@@ -321,6 +331,15 @@ Proof.
     destruct r as [a r].
     destruct r as [b r].
     snrapply path_forall.
+    snrapply Pushout_ind.
+    + intro a'.
+      simpl.
+
+      
+
+
+
+
     
 
 

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -63,31 +63,14 @@ Section Sequence.
   Definition concatPQ (Z : zigzag_type) : Dot R (Pp Z) (Q Z)
     := dot_step (flip R) (concatQPp Z).
 
-  Definition iotaQ (Z : zigzag_type) : forall (b : B) (x : Qp Z b), Q Z b
-    := iota_step (flip R) (concatQPp Z).
-
   Definition P (Z : zigzag_type) : Family A
     := family_step R (concatPQ Z).
 
   Definition concatQP (Z : zigzag_type) : Dot (flip R) (Q Z) (P Z)
     := dot_step R (concatPQ Z).
 
-  Definition iotaP (Z : zigzag_type) : forall (a : A) (x : Pp Z a), P Z a
-    := iota_step R (concatPQ Z).
-
-  Definition concatQPQ (Z : zigzag_type)
-    : forall (b : B) (a : A) (r : R a b), (compose (concatPQ Z a b r) (concatQPp Z b a r)) == (iotaQ Z b)
-    := homotopy_step (flip R) (concatQPp Z).
-
-  Definition concatPQP (Z : zigzag_type)
-    : forall (a : A) (b : B) (r : R a b), (compose (concatQP Z b a r) (concatPQ Z a b r)) == (iotaP Z a)
-    := homotopy_step R (concatPQ Z).
-
-  Definition zigzag_step : zigzag_type -> zigzag_type.
-  Proof.
-    intro Z.
-    exact (Build_zigzag_type (P Z) (Q Z) (concatQP Z)).
-  Defined.
+  Definition zigzag_step (Z : zigzag_type) : zigzag_type
+    := Build_zigzag_type (P Z) (Q Z) (concatQP Z).
 
   Definition identity_zigzag_initial : zigzag_type.
   Proof.
@@ -105,7 +88,7 @@ Section Sequence.
     intro a.
     snrapply Build_Sequence.
     - intro n; exact (P (identity_zigzag n) a).
-    - intro n; exact (iotaP (identity_zigzag (S n)) a).
+    - intro n. unfold P; cbn. apply iota_step.
   Defined.
 
   Definition identity_zigzag_Q_seq : B -> Sequence.
@@ -113,7 +96,7 @@ Section Sequence.
     intro b.
     snrapply Build_Sequence.
     - intro n; exact (Q (identity_zigzag n) b).
-    - intro n; exact (iotaQ (identity_zigzag (S n)) b).
+    - intro n. unfold Q; cbn. apply iota_step.
   Defined.
 
   Definition identity_zigzag_concatPQ_seq {a : A} {b : B} (r : R a b) 
@@ -123,11 +106,9 @@ Section Sequence.
     - intro n; exact (concatPQ (identity_zigzag (S n)) a b r).
     - intros n m g x.
       destruct g.
-      transitivity (concatPQ (identity_zigzag (S (S n))) a b r (concatQP (identity_zigzag (S n)) b a r (concatPQ (identity_zigzag (S n)) a b r x))).
-      + symmetry.
-        exact (concatQPQ (identity_zigzag (S (S n))) b a r _).
-      + apply ap.
-        exact (concatPQP (identity_zigzag (S n)) a b r _).
+      lhs_V nrapply homotopy_step.
+      apply ap.
+      apply homotopy_step.
   Defined.
 
   Definition identity_zigzag_concatQP_seq {a : A} {b : B} (r : R a b) 
@@ -137,11 +118,9 @@ Section Sequence.
     - intro n; exact (concatQP (identity_zigzag n) b a r).
     - intros n m g x.
       destruct g.
-      transitivity (concatQP (identity_zigzag (S n)) b a r (concatPQ (identity_zigzag (S n)) a b r (concatQP (identity_zigzag n) b a r x))).
-      + symmetry.
-        exact (concatPQP (identity_zigzag (S n)) a b r _).
-      + apply ap.
-        exact (concatQPQ (identity_zigzag (S n)) b a r _).
+      lhs_V nrapply homotopy_step.
+      apply ap.
+      apply homotopy_step.
   Defined.
 
 End Sequence.

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -9,233 +9,151 @@ Require Import Colimits.Sequential.
 Require Import Diagram.
 Require Import Types.
 
-Definition pred_type_or_empty (P : nat -> Type) (t : nat) : Type.
-Proof.
-  induction t.
-  - exact Empty.
-  - exact (P t).
-Defined.
+(** * Work towards characterizing the path types in a pushout of a span [R : A -> B -> Type]. *)
 
-Record zigzag_type {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) 
-  : Type := {
+(** The goal here is to work in half-steps, so that each construction only happens once. *)
+
+(** [C] will be used to denote a type that might be [A] or [B].  We think of a term of [Family C] as being the family [fun c => a0 squiggle_t c]. *)
+Definition Family (C : Type) := C -> Type.
+
+(** Here [P a] should be thought of as [a_0 squiggle_t a] and [Q b] as [a_0 squiggle_{t+1} b].  This describes the type of the "dot" operation [- ._t -]. This will also be used with [A] and [B] swapped and [R] flipped. *)
+Definition Dot {A B : Type} (R : A -> B -> Type) (P : Family A) (Q : Family B)
+  := forall (a : A) (b : B) (r : R a b) (p : P a), Q b.
+
+Section InductiveStep.
+
+  (** Given two families [P] and [Q] and a dot map from [P] to [Q], we define one more family [P'], a stage map from [Q] to [P'] (relative to the flipped relation), and a fiberwise map iota from [P] to [P']. Note that [flip R] has type [B -> A -> Type]. *)
+
+  Context {A B : Type} (R : A -> B -> Type).
+  Context {P : Family A} {Q : Family B} (dot : Dot R P Q).
+
+  (** We define the new type family as the pushout. *)
+  Definition family_step : Family A.
+  Proof.
+    intro a.
+    snrapply (@Pushout ({b : B & R a b} * P a) (P a) {b : B & (R a b * Q b)}).
+    - exact snd.
+    - intros [[b r] p].
+      exact (b; (r, dot a b r p)).
+  Defined.
+
+  (** We define the next "dot" map as [pushr]. *)
+  Definition dot_step : Dot (flip R) Q family_step
+    := fun b a r q => pushr (b; (r, q)).
+
+  (** We define iota as [pushl]. *)
+  Definition iota_step : forall a, P a -> family_step a
+    := fun a p => pushl p.
+
+  (** We define the homotopy showing that the composition of the two dot maps is iota. *)
+  Definition homotopy_step : forall (a : A) (b : B) (r : R a b), 
+    (dot_step b a r) o (dot a b r) == (iota_step a) 
+    := fun a b r p => inverse (pglue ((b ; r) , p)).
+End InductiveStep.
+
+Section Sequence.
+  Context {A B : Type} (R : A -> B -> Type) (a0 : A).
+
+  (** Use a record type for a full step to avoid the interleaved sequence and `flip R`. *)
+  Record zigzag_type : Type := {
     Pp : A -> Type; (** Stored from previous step *)
     Qp : B -> Type; (** Stored from previous step *)
-    concatQPp (a : A) (b : B) (r : R a b) (q : Qp b) : Pp a; (** Stored from previous step *)
+    concatQPp (b : B) (a : A) (r : R a b) (q : Qp b) : Pp a; (** Stored from previous step *)
     Q : B -> Type; (** Paths of length t *)
     concatPQ (a : A) (b : B) (r : R a b) (p : Pp a) : Q b; (** t-1 -> t *)
     iotaQ (b : B) (x : Qp b) : Q b; (** t-2 -> t *)
     P : A -> Type; (** Paths of length t+1 *)
-    concatQP (a : A) (b : B) (r : R a b) (q : Q b) : P a; (** t -> t+1 *)
+    concatQP (b : B) (a : A) (r : R a b) (q : Q b) : P a; (** t -> t+1 *)
     iotaP (a : A) (x : Pp a) : P a; (** t-1 -> t+1 *)
-    concatQPQ (a : A) (b : B) (r : R a b) 
-      : (compose (concatPQ a b r) (concatQPp a b r)) == (iotaQ b);
+    concatQPQ (b : B) (a : A) (r : R a b) 
+      : (compose (concatPQ a b r) (concatQPp b a r)) == (iotaQ b);
     concatPQP (a : A) (b : B) (r : R a b) 
-      : (compose (concatQP a b r) (concatPQ a b r)) == (iotaP a);
+      : (compose (concatQP b a r) (concatPQ a b r)) == (iotaP a);
   }.
 
-Definition zigzag_step {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (z : zigzag_type R a0) 
-  : zigzag_type R a0.
-Proof.
-  destruct z.
-  snrapply (let Pp:=_ in let Qp :=_ in let concatQPp :=_ in let Q:=_ in let concatPQ:=_ in let iotaQ:=_ in let P:=_ in let concatQP:=_ in let iotaP:=_ in let concatQPQ:=_ in let concatPQP:=_ in Build_zigzag_type A B R a0 Pp Qp concatQPp Q concatPQ iotaQ P concatQP iotaP concatQPQ concatPQP).
-  - exact P0.
-  - exact Q0.
-  - exact concatQP0.
-  - intros b. (** Constructing Q_t *)
-    snrapply Pushout.
-    + exact (sig (fun a => prod (R a b) (Q0 b))).
-    + exact (Q0 b).
-    + exact (sig (fun a => prod (R a b) (P0 a))).
-    + intro x.
-      exact (snd (pr2 x)).
-    + intros [a [r p]].
-      exact (a ; (r , (concatQP0 a b r p))).
-  - intros a b r p. (** Constructing P_{t-1} -> Q_t (concatPQ) *)
-    snrapply pushr.
-    exact (a ; (r , p)).
-  - intros b. (** Constructing Q_{t-1} -> Q_t *)
-    exact pushl.
-  - intro a. (** Constructing P_t *)
-    snrapply Pushout.
-    + exact (sig (fun b => prod (R a b) (P0 a))).
-    + exact (P0 a).
-    + exact (sig (fun b => prod (R a b) (Q b))).
-    + intro x.
-      exact (snd (pr2 x)).
-    + intros [b [r p]].
-      exact (b ; (r , concatPQ a b r p)).
-  - intros a b r p. (** Consructing Q_t -> P_t (concatQP) *)
-    snrapply pushr.
-    exact (b ; (r , p)).
-  - intros a. (** Constructing P_{t-1} -> P_t *)
-    exact pushl.
-  - intros a b r.
-    transparent assert (incl : ((Qp b) -> (sig (fun a' => prod (R a' b) (Qp b))))). {
-      intro q'.
-      exact (a ; (r , q')).
-    }
-    transparent assert (proj : ((sig (fun a' => prod (R a' b) (Qp b))) -> (Qp b))). {
-      intro x.
-      destruct x.
-      destruct proj2.
-      exact snd.
-    }
-    transparent assert (H : (proj o incl == idmap)). {
-      intro x.
-      reflexivity.
-    }
-    transitivity ((iotaQ b) o proj o incl).
-    + intro q.
-      unfold concatPQ.
-      unfold iotaQ.
-      symmetry.
-      unfold incl.
-      exact (pglue (a ; (r , q))).
-    + intro q.
-      apply ap.
-      exact (H q).
-  - intros a b r.
-    transparent assert (incl : ((Pp a) -> (sig (fun b' => prod (R a b') (Pp a))))). {
-      intro p'.
-      exact (b ; (r , p')).
-    }
-    transparent assert (proj : ((sig (fun b' => prod (R a b') (Pp a))) -> (Pp a))). {
-      intro x.
-      destruct x.
-      destruct proj2.
-      exact snd.
-    }
-    transparent assert (H : (proj o incl == idmap)). {
-      intro x.
-      reflexivity.
-    }
-    transitivity ((iotaP a) o proj o incl).
-    + intro q.
-      unfold concatPQ.
-      unfold iotaQ.
-      symmetry.
-      unfold incl.
-      exact (pglue (b ; (r , q))).
-    + intro q.
-      apply ap.
-      exact (H q).
-Defined.
+  Definition zigzag_step : zigzag_type -> zigzag_type.
+  Proof.
+    intro z.
+    destruct z.
+    (* Naming them all seems to be necessary for Coq to not reorder goals. *)
+    snrapply (let Pp:=_ in let Qp :=_ in let concatQPp :=_ in let Q:=_ in let concatPQ:=_ in let iotaQ:=_ in let P:=_ in let concatQP:=_ in let iotaP:=_ in let concatQPQ:=_ in let concatPQP:=_ in Build_zigzag_type Pp Qp concatQPp Q concatPQ iotaQ P concatQP iotaP concatQPQ concatPQP).
+    - exact P0.
+    - exact Q0.
+    - exact concatQP0.
+    - exact (family_step (flip R) concatQP0).
+    - exact (dot_step (flip R) concatQP0).
+    - exact (iota_step (flip R) concatQP0).
+    - exact (family_step R concatPQ).
+    - exact (dot_step R concatPQ).
+    - exact (iota_step R concatPQ).
+    - exact (homotopy_step (flip R) concatQP0).
+    - exact (homotopy_step R concatPQ).
+  Defined.
 
-Definition identity_zigzag_initial {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) : zigzag_type R a0.
-Proof.
-  snrapply (Build_zigzag_type A B R a0).
-  1, 2, 4: exact (fun b => Empty). (** Define Q_0 := Empty *)
-  4: exact (fun a => a0 = a). (** Define P_0 := Id a0 *)
-  all: intros.
-  - destruct q.
-  - destruct p. (** Define P_{-1} -> Q_0 *)
-  - destruct x. (** Define Q_{-1} -> Q_0 *)
-  - destruct q. (** Define Q_0 -> P_0 *)
-  - destruct x. (** Define P_{-1} -> P_0 *)
-  - intros [].
-  - intros [].
-Defined.
+  Definition identity_zigzag_initial : zigzag_type.
+  Proof.
+    snrapply Build_zigzag_type.
+    - exact (fun a => Empty).
+    - exact (fun b => Empty).
+    - intros b a r q; destruct q.
+    - exact (fun b => Empty). (** Define Q0 := Empty *)
+    - intros a b r q; destruct q.
+    - intros b q; destruct q.
+    - exact (fun a => a0 = a). (** Define P0 := Id a0 *)
+    - intros b a r q; destruct q. (** Define Q0 -> P_0 *)
+    - intros a q; destruct q. (** Define P_{-1} -> P0 *)
+    - intros; intro q; destruct q.
+    - intros; intro q; destruct q.
+  Defined.
 
-Definition identity_zigzag {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (t : nat) 
-  : zigzag_type R a0 := 
-  nat_iter t (fun x => zigzag_step R a0 x) (identity_zigzag_initial R a0).
+  Definition identity_zigzag : nat -> zigzag_type
+    := fun n => nat_iter n zigzag_step identity_zigzag_initial.
 
-Definition identity_zigzag_P {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) (t : nat) 
-  : Type := 
-  (identity_zigzag R a0 t).(P R a0) a.
+  Definition identity_zigzag_P_seq : A -> Sequence.
+  Proof.
+    intro a.
+    snrapply Build_Sequence.
+    - intro n; exact ((identity_zigzag n).(P) a).
+    - intro n; exact ((identity_zigzag (S n)).(iotaP) a).
+  Defined.
 
-Definition identity_zigzag_iotaP {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) (t : nat) 
-  : (identity_zigzag_P R a0 a t) -> (identity_zigzag_P R a0 a (S t)) := 
-  (identity_zigzag R a0 (S t)).(iotaP R a0) a.
+  Definition identity_zigzag_Q_seq : B -> Sequence.
+  Proof.
+    intro b.
+    snrapply Build_Sequence.
+    - intro n; exact ((identity_zigzag n).(Q) b).
+    - intro n; exact ((identity_zigzag (S n)).(iotaQ) b).
+  Defined.
 
-Definition identity_zigzag_P_seq {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) : Sequence.
-Proof.
-  snrapply Build_Sequence.
-  - exact (identity_zigzag_P R a0 a).
-  - exact (identity_zigzag_iotaP R a0 a).
-Defined.
+  Definition identity_zigzag_concatPQ_seq {a : A} {b : B} (r : R a b) 
+    : DiagramMap (identity_zigzag_P_seq a) (succ_seq (identity_zigzag_Q_seq b)).
+  Proof.
+    snrapply Build_DiagramMap.
+    - intro n; exact ((identity_zigzag (S n)).(concatPQ) a b r).
+    - intros n m g x.
+      destruct g.
+      transitivity ((identity_zigzag (S (S n))).(concatPQ) a b r ((identity_zigzag (S n)).(concatQP) b a r ((identity_zigzag (S n)).(concatPQ) a b r x))).
+      + symmetry.
+        exact ((identity_zigzag (S (S n))).(concatQPQ) b a r _).
+      + apply ap.
+        exact ((identity_zigzag (S n)).(concatPQP) a b r _).
+  Defined.
 
-Definition identity_zigzag_Q {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (b : B) (t : nat) : Type := 
-  (identity_zigzag R a0 t).(Q R a0) b.
+  Definition identity_zigzag_concatQP_seq {a : A} {b : B} (r : R a b) 
+    : DiagramMap (identity_zigzag_Q_seq b) (identity_zigzag_P_seq a).
+  Proof.
+    snrapply Build_DiagramMap.
+    - intro n; exact ((identity_zigzag n).(concatQP) b a r).
+    - intros n m g x.
+      destruct g.
+      transitivity ((identity_zigzag (S n)).(concatQP) b a r ((identity_zigzag (S n)).(concatPQ) a b r ((identity_zigzag n).(concatQP) b a r x))).
+      + symmetry.
+        exact ((identity_zigzag (S n)).(concatPQP) a b r _).
+      + apply ap.
+        exact ((identity_zigzag (S n)).(concatQPQ) b a r _).
+  Defined.
 
-Definition identity_zigzag_iotaQ {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (b : B) (t : nat) 
-  : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_Q R a0 b (S t)) := 
-  (identity_zigzag R a0 (S t)).(iotaQ R a0) b.
-
-Definition identity_zigzag_Q_seq {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (b : B) : Sequence.
-Proof.
-  snrapply Build_Sequence.
-  - exact (identity_zigzag_Q R a0 b).
-  - exact (identity_zigzag_iotaQ R a0 b).
-Defined.
-
-Definition identity_zigzag_concatQP {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) 
-  : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_P R a0 a t) := 
-  (identity_zigzag R a0 t).(concatQP R a0) a b r.
-
-
-Definition identity_zigzag_concatPQ {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) 
-  : (identity_zigzag_P R a0 a t) -> (identity_zigzag_Q R a0 b (S t)) := 
-  (identity_zigzag R a0 (S t)).(concatPQ R a0) a b r.
-
-Definition identity_zigzag_concatQPQ {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) 
-  : (compose (identity_zigzag_concatPQ R a0 a b r t) 
-    (identity_zigzag_concatQP R a0 a b r t)) 
-  == (identity_zigzag_iotaQ R a0 b t) := 
-  (identity_zigzag R a0 (S t)).(concatQPQ R a0) a b r.
-
-Definition identity_zigzag_concatPQP {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : 
-  (compose (identity_zigzag_concatQP R a0 a b r (S t)) 
-    (identity_zigzag_concatPQ R a0 a b r t)) 
-  == (identity_zigzag_iotaP R a0 a t) := 
-  (identity_zigzag R a0 (S t)).(concatPQP R a0) a b r.
-
-Definition identity_zigzag_seq_concatQP {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) (b : B) (r : R a b) 
-  : DiagramMap (identity_zigzag_Q_seq R a0 b) (identity_zigzag_P_seq R a0 a).
-Proof.
-  snrapply Build_DiagramMap.
-  - intro t.
-    exact (identity_zigzag_concatQP R a0 a b r t).
-  - intros t p q x.
-    destruct q.
-    simpl.
-    transitivity (identity_zigzag_concatQP R a0 a b r (S t) (identity_zigzag_concatPQ R a0 a b r t (identity_zigzag_concatQP R a0 a b r t x))).
-    + symmetry.
-      exact (identity_zigzag_concatPQP R a0 a b r t _).
-    + apply ap.
-      exact (identity_zigzag_concatQPQ R a0 a b r t _).
-Defined.
-
-Definition identity_zigzag_seq_concatPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) 
-  (a : A) (b : B) (r : R a b) 
-  : DiagramMap (identity_zigzag_P_seq R a0 a) (succ_seq (identity_zigzag_Q_seq R a0 b)).
-Proof.
-  snrapply Build_DiagramMap.
-  - intro t.
-    exact (identity_zigzag_concatPQ R a0 a b r t).
-  - intros t p q x.
-    destruct q.
-    simpl.
-    transitivity (identity_zigzag_concatPQ R a0 a b r (S t) (identity_zigzag_concatQP R a0 a b r (S t) (identity_zigzag_concatPQ R a0 a b r t x))).
-    + symmetry.
-      exact (identity_zigzag_concatQPQ R a0 a b r (S t) _).
-    + apply ap.
-      exact (identity_zigzag_concatPQP R a0 a b r t _).
-Defined.
+End Sequence.
 
 Definition identity_zigzag_Pinf {A : Type} {B : Type} (R : A -> B -> Type) 
   (a0 : A) (a : A) : Type := 

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -51,19 +51,21 @@ Section InductiveStep.
     := fun a b r p => inverse (pglue ((b ; r) , p)).
 End InductiveStep.
 
+Definition Dot {A B : Type} (R : A -> B -> Type) (P : Family A) (Q : Family B)
+  := forall (a : A) (b : B) (r : R a b) (p : P a), Q b.
 Section Sequence.
   Context {A B : Type} (R : A -> B -> Type) (a0 : A).
 
   (** Use a record type for a full step to avoid the interleaved sequence and `flip R`. *)
   Record zigzag_type : Type := {
-    Pp : A -> Type; (** Stored from previous step *)
-    Qp : B -> Type; (** Stored from previous step *)
-    concatQPp (b : B) (a : A) (r : R a b) (q : Qp b) : Pp a; (** Stored from previous step *)
-    Q : B -> Type; (** Paths of length t *)
-    concatPQ (a : A) (b : B) (r : R a b) (p : Pp a) : Q b; (** t-1 -> t *)
+    Pp : Family A; (** Stored from previous step *)
+    Qp : Family B; (** Stored from previous step *)
+    concatQPp : Dot (flip R) Qp Pp; (** Stored from previous step *)
+    Q : Family B; (** Paths of length t *)
+    concatPQ : Dot R Pp Q; (** t-1 -> t *)
     iotaQ (b : B) (x : Qp b) : Q b; (** t-2 -> t *)
-    P : A -> Type; (** Paths of length t+1 *)
-    concatQP (b : B) (a : A) (r : R a b) (q : Q b) : P a; (** t -> t+1 *)
+    P : Family A; (** Paths of length t+1 *)
+    concatQP : Dot (flip R) Q P; (** t -> t+1 *)
     iotaP (a : A) (x : Pp a) : P a; (** t-1 -> t+1 *)
     concatQPQ (b : B) (a : A) (r : R a b) 
       : (compose (concatPQ a b r) (concatQPp b a r)) == (iotaQ b);
@@ -73,21 +75,18 @@ Section Sequence.
 
   Definition zigzag_step : zigzag_type -> zigzag_type.
   Proof.
-    intro z.
-    destruct z.
+    intros [_ _ _ Q0 _ _ P0 concatQP0 _ _ _];
+    pose (concatPQ := dot_step (flip R) concatQP0).
     (* Naming them all seems to be necessary for Coq to not reorder goals. *)
-    snrapply (let Pp:=_ in let Qp :=_ in let concatQPp :=_ in let Q:=_ in let concatPQ:=_ in let iotaQ:=_ in let P:=_ in let concatQP:=_ in let iotaP:=_ in let concatQPQ:=_ in let concatPQP:=_ in Build_zigzag_type Pp Qp concatQPp Q concatPQ iotaQ P concatQP iotaP concatQPQ concatPQP).
-    - exact P0.
-    - exact Q0.
-    - exact concatQP0.
-    - exact (family_step (flip R) concatQP0).
-    - exact (dot_step (flip R) concatQP0).
-    - exact (iota_step (flip R) concatQP0).
-    - exact (family_step R concatPQ).
-    - exact (dot_step R concatPQ).
-    - exact (iota_step R concatPQ).
-    - exact (homotopy_step (flip R) concatQP0).
-    - exact (homotopy_step R concatPQ).
+    snrapply (Build_zigzag_type P0 Q0 concatQP0).
+      - exact (family_step (flip R) concatQP0).
+      - exact concatPQ.
+      - exact (iota_step (flip R) concatQP0).
+      - exact (family_step R concatPQ).
+      - exact (dot_step R concatPQ).
+      - exact (iota_step R concatPQ).
+      - exact (homotopy_step (flip R) concatQP0).
+      - exact (homotopy_step R concatPQ).
   Defined.
 
   Definition identity_zigzag_initial : zigzag_type.

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -4,8 +4,10 @@ Require Import Spaces.Nat.
 Require Import Basics.Tactics.
 Require Import Diagrams.Sequence.
 Require Import WildCat.
-
-Set Implicit Arguments.
+Require Import Colimits.Colimit.
+Require Import Colimits.Sequential.
+Require Import Diagram.
+Require Import Types.
 
 Definition pred_type_or_empty (P : nat -> Type) (t : nat) : Type.
 Proof.
@@ -24,14 +26,14 @@ Record zigzag_type {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) : Type :=
   P : A -> Type; (** Paths of length t+1 *)
   concatQP (a : A) (b : B) (r : R a b) (q : Q b) : P a; (** t -> t+1 *)
   iotaP (a : A) (x : Pp a) : P a; (** t-1 -> t+1 *)
-  concatQPQ (a : A) (b : B) (r : R a b) : (compose (concatPQ r) (concatQPp r)) == (iotaQ (b := b));
-  concatPQP (a : A) (b : B) (r : R a b) : (compose (concatQP r) (concatPQ r)) == (iotaP (a := a));
+  concatQPQ (a : A) (b : B) (r : R a b) : (compose (concatPQ a b r) (concatQPp a b r)) == (iotaQ b);
+  concatPQP (a : A) (b : B) (r : R a b) : (compose (concatQP a b r) (concatPQ a b r)) == (iotaP a);
 }.
 
 Definition zigzag_step {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (z : zigzag_type R a0) : zigzag_type R a0.
 Proof.
   destruct z.
-  snrapply (let Pp:=_ in let Qp :=_ in let concatQPp :=_ in let Q:=_ in let concatPQ:=_ in let iotaQ:=_ in let P:=_ in let concatQP:=_ in let iotaP:=_ in let concatQPQ:=_ in let concatPQP:=_ in Build_zigzag_type R a0 Pp Qp concatQPp Q concatPQ iotaQ P concatQP iotaP concatQPQ concatPQP).
+  snrapply (let Pp:=_ in let Qp :=_ in let concatQPp :=_ in let Q:=_ in let concatPQ:=_ in let iotaQ:=_ in let P:=_ in let concatQP:=_ in let iotaP:=_ in let concatQPQ:=_ in let concatPQP:=_ in Build_zigzag_type A B R a0 Pp Qp concatQPp Q concatPQ iotaQ P concatQP iotaP concatQPQ concatPQP).
   - exact P0.
   - exact Q0.
   - exact concatQP0.
@@ -48,7 +50,7 @@ Proof.
       exact (a ; (r , (concatQP0 a b r p))).
   - intros a b r p. (** Constructing P_{t-1} -> Q_t (concatPQ) *)
     snrapply pushr.
-    exact (a ; (r , p)).
+exact (a ; (r , p)).
   - intros b. (** Constructing Q_{t-1} -> Q_t *)
     exact pushl.
   - intro a. (** Constructing P_t *)
@@ -62,7 +64,7 @@ Proof.
       destruct b as [b p2].
       destruct p2 as [r p].
       exact (b ; (r , concatPQ a b r p)).
-  - intros a b r p. (** Consructin Q_t -> P_t (concatQP) *)
+  - intros a b r p. (** Consructing Q_t -> P_t (concatQP) *)
     snrapply pushr.
     exact (b ; (r , p)).
   - intros a. (** Constructing P_{t-1} -> P_t *)
@@ -83,17 +85,45 @@ Proof.
       reflexivity.
     }
     transitivity ((iotaQ b) o proj o incl).
-    + admit.
+    + intro q.
+      unfold concatPQ.
+      unfold iotaQ.
+      symmetry.
+      unfold incl.
+      exact (pglue (a ; (r , q))).
     + intro q.
       apply ap.
-      exact 
-
-
-
+      exact (H q).
+  - intros a b r.
+    transparent assert (incl : ((Pp a) -> (sig (fun b' => prod (R a b') (Pp a))))). {
+      intro p'.
+      exact (b ; (r , p')).
+    }
+    transparent assert (proj : ((sig (fun b' => prod (R a b') (Pp a))) -> (Pp a))). {
+      intro x.
+      destruct x.
+      destruct proj2.
+      exact snd.
+    }
+    transparent assert (H : (proj o incl == idmap)). {
+      intro x.
+      reflexivity.
+    }
+    transitivity ((iotaP a) o proj o incl).
+    + intro q.
+      unfold concatPQ.
+      unfold iotaQ.
+      symmetry.
+      unfold incl.
+      exact (pglue (b ; (r , q))).
+    + intro q.
+      apply ap.
+      exact (H q).
+Defined.
 
 Definition identity_zigzag_initial {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) : zigzag_type R a0.
 Proof.
-  snrapply (Build_zigzag_type R a0).
+  snrapply (Build_zigzag_type A B R a0).
   - exact (fun a => Empty).
   - exact (fun b => Empty).
   - intros a b r q.
@@ -108,13 +138,19 @@ Proof.
     destruct q.
   - intros a p. (** Define P_{-1} -> P_0 *)
     destruct p.
+  - intros.
+    intro q.
+    destruct q.
+  - intros.
+    intro q.
+    destruct q.
 Defined.
 
-Definition identity_zigzag {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (t : nat) : zigzag_type R a0 := nat_iter t (fun x => zigzag_step x) (identity_zigzag_initial R a0).
+Definition identity_zigzag {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (t : nat) : zigzag_type R a0 := nat_iter t (fun x => zigzag_step R a0 x) (identity_zigzag_initial R a0).
 
-Definition identity_zigzag_P {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (t : nat) : Type := (identity_zigzag R a0 t).(P) a.
+Definition identity_zigzag_P {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (t : nat) : Type := (identity_zigzag R a0 t).(P R a0) a.
 
-Definition identity_zigzag_iotaP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (t : nat) : (identity_zigzag_P R a0 a t) -> (identity_zigzag_P R a0 a (S t)) := (identity_zigzag R a0 (S t)).(iotaP) a.
+Definition identity_zigzag_iotaP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (t : nat) : (identity_zigzag_P R a0 a t) -> (identity_zigzag_P R a0 a (S t)) := (identity_zigzag R a0 (S t)).(iotaP R a0) a.
 
 Definition identity_zigzag_P_seq {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) : Sequence.
 Proof.
@@ -123,9 +159,9 @@ Proof.
   - exact (identity_zigzag_iotaP R a0 a).
 Defined.
 
-Definition identity_zigzag_Q {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) (t : nat) : Type := (identity_zigzag R a0 t).(Q) b.
+Definition identity_zigzag_Q {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) (t : nat) : Type := (identity_zigzag R a0 t).(Q R a0) b.
 
-Definition identity_zigzag_iotaQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) (t : nat) : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_Q R a0 b (S t)) := (identity_zigzag R a0 (S t)).(iotaQ) b.
+Definition identity_zigzag_iotaQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) (t : nat) : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_Q R a0 b (S t)) := (identity_zigzag R a0 (S t)).(iotaQ R a0) b.
 
 Definition identity_zigzag_Q_seq {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) : Sequence.
 Proof.
@@ -134,15 +170,158 @@ Proof.
   - exact (identity_zigzag_iotaQ R a0 b).
 Defined.
 
-Definition identity_zigzag_concatQP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_P R a0 a t) := (identity_zigzag R a0 t).(concatQP) a b r.
+Definition identity_zigzag_concatQP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (identity_zigzag_Q R a0 b t) -> (identity_zigzag_P R a0 a t) := (identity_zigzag R a0 t).(concatQP R a0) a b r.
 
 
-Definition identity_zigzag_concatPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (identity_zigzag_P R a0 a t) -> (identity_zigzag_Q R a0 b (S t)) := (identity_zigzag R a0 (S t)).(concatPQ) a b r.
+Definition identity_zigzag_concatPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (identity_zigzag_P R a0 a t) -> (identity_zigzag_Q R a0 b (S t)) := (identity_zigzag R a0 (S t)).(concatPQ R a0) a b r.
 
-Definition identity_zigzag_concatQPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (compose (identity_zigzag_concatPQ R a0 a b r t) (identity_zigzag_concatQP R a0 a b r t)) == (identity_zigzag_iotaQ R a0 b t).
+Definition identity_zigzag_concatQPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (compose (identity_zigzag_concatPQ R a0 a b r t) (identity_zigzag_concatQP R a0 a b r t)) == (identity_zigzag_iotaQ R a0 b t) := (identity_zigzag R a0 (S t)).(concatQPQ R a0) a b r.
+
+Definition identity_zigzag_concatPQP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) (t : nat) : (compose (identity_zigzag_concatQP R a0 a b r (S t)) (identity_zigzag_concatPQ R a0 a b r t)) == (identity_zigzag_iotaP R a0 a t) := (identity_zigzag R a0 (S t)).(concatPQP R a0) a b r.
+
+Definition identity_zigzag_seq_concatQP {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : DiagramMap (identity_zigzag_Q_seq R a0 b) (identity_zigzag_P_seq R a0 a).
 Proof.
-  intro p.
-  induction t.
-  - destruct p.
-  - 
+  snrapply Build_DiagramMap.
+  - intro t.
+    exact (identity_zigzag_concatQP R a0 a b r t).
+  - intros t p q x.
+    destruct q.
+    simpl.
+    transitivity (identity_zigzag_concatQP R a0 a b r (S t) (identity_zigzag_concatPQ R a0 a b r t (identity_zigzag_concatQP R a0 a b r t x))).
+    + symmetry.
+      exact (identity_zigzag_concatPQP R a0 a b r t _).
+    + apply ap.
+      exact (identity_zigzag_concatQPQ R a0 a b r t _).
+Defined.
 
+Definition identity_zigzag_seq_concatPQ {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : DiagramMap (identity_zigzag_P_seq R a0 a) (succ_seq (identity_zigzag_Q_seq R a0 b)).
+Proof.
+  snrapply Build_DiagramMap.
+  - intro t.
+    simpl.
+    Compute (Graph.graph0 sequence_graph).
+    exact (identity_zigzag_concatPQ R a0 a b r t).
+  - intros t p q x.
+    destruct q.
+    simpl.
+    transitivity (identity_zigzag_concatPQ R a0 a b r (S t) (identity_zigzag_concatQP R a0 a b r (S t) (identity_zigzag_concatPQ R a0 a b r t x))).
+    + symmetry.
+      exact (identity_zigzag_concatQPQ R a0 a b r (S t) _).
+    + apply ap.
+      exact (identity_zigzag_concatPQP R a0 a b r t _).
+Defined.
+
+Definition identity_zigzag_Pinf {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) : Type := Colimit (identity_zigzag_P_seq R a0 a).
+
+Definition identity_zigzag_Qinf {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (b : B) : Type := Colimit (identity_zigzag_Q_seq R a0 b).
+
+Definition identity_zigzag_concatQPinf `{Funext} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : (identity_zigzag_Qinf R a0 b) -> (identity_zigzag_Pinf R a0 a) := functor_colimit (identity_zigzag_seq_concatQP R a0 a b r) _ _.
+
+Definition identity_zigzag_concatPQinf `{Funext} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : (identity_zigzag_Pinf R a0 a) -> (identity_zigzag_Qinf R a0 b) := (colim_succ_seq_to_colim_seq _) o (functor_colimit (identity_zigzag_seq_concatPQ R a0 a b r) _ _ ).
+
+Section Death.
+  Context `{Funext} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b).
+
+  Check (identity_zigzag_concatPQinf).
+
+End Death.
+
+Definition identity_zigzag_concatinf_retr `{Univalence} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : (identity_zigzag_concatPQinf R a0 a b r) o (identity_zigzag_concatQPinf R a0 a b r) == idmap.
+Proof.
+  snrapply Colimit_ind.
+  - simpl.
+    intros t p.
+    transitivity (inj (identity_zigzag_Q_seq R a0 b) (S t) (identity_zigzag_concatPQ R a0 a b r t (identity_zigzag_concatQP R a0 a b r t p))).
+    + reflexivity.
+    + transitivity (inj (identity_zigzag_Q_seq R a0 b) (S t) (identity_zigzag_iotaQ R a0 b t p)).
+      * apply ap.
+        exact (identity_zigzag_concatQPQ R a0 a b r t p).
+      * apply (glue (identity_zigzag_Q_seq R a0 b)).
+  - intros t n q p.
+    destruct q.
+    admit.
+Admitted.
+
+Definition identity_zigzag_concatinf_sec `{Univalence} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : (identity_zigzag_concatQPinf R a0 a b r) o (identity_zigzag_concatPQinf R a0 a b r) == idmap.
+Proof.
+Admitted.
+
+Definition isequiv_identity_zigzag_concatinf `{Univalence} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) : IsEquiv (identity_zigzag_concatPQinf R a0 a b r).
+Proof.
+  snrapply isequiv_adjointify.
+  2: exact (identity_zigzag_concatinf_retr R a0 a b r).
+  exact (identity_zigzag_concatinf_sec R a0 a b r).
+Defined.
+
+Definition relation_type {A : Type} {B : Type} (R : A -> B -> Type) : Type := { a : A | { b : B | R a b}}.
+
+Definition relation_pr1 {A: Type} {B : Type} (R : A -> B -> Type) : (relation_type R) -> A := pr1.
+
+Definition relation_pr2 {A: Type} {B : Type} (R : A -> B -> Type) : (relation_type R) -> B.
+Proof.
+  intro a.
+  destruct a as [a b].
+  exact (pr1 b).
+Defined.
+
+Definition relation_flip {A : Type} {B : Type} (R : A -> B -> Type) : forall (b : B)  (a : A), Type.
+Proof.
+  intros b a.
+  exact (R a b).
+Defined.
+
+Definition Pushout_relation {A : Type} {B : Type} (R : A -> B -> Type) : Type.
+Proof.
+  snrapply Pushout.
+  - exact (relation_type R).
+  - exact A.
+  - exact B.
+  - intro a.
+    destruct a as [a b].
+    destruct b as [b r].
+    exact a.
+  - intro a.
+    destruct a as [a b].
+    destruct b as [b r].
+    exact b.
+Defined.
+
+Definition identity_zigzag_family `{Univalence} {A : Type} {B : Type} (R : A -> B -> Type) : (Pushout_relation R) -> (Pushout_relation R) -> Type.
+Proof.
+  snrapply Pushout_rec.
+  - intro x.
+    snrapply Pushout_rec.
+    + intro y.
+      exact (identity_zigzag_Pinf R x y).
+    + intro y.
+      exact (identity_zigzag_Qinf R x y).
+    + intro r.
+      destruct r as [a r].
+      destruct r as [b r].
+      snrapply path_universe_uncurried.
+      snrapply Build_Equiv.
+      * exact (identity_zigzag_concatPQinf R x a b r).
+      * exact (isequiv_identity_zigzag_concatinf R x a b r).
+  - intro x.
+    pose (R' := (relation_flip R)).
+    snrapply Pushout_rec.
+    + intro y.
+      exact (identity_zigzag_Qinf R' x y).
+    + intro y.
+      exact (identity_zigzag_Pinf R' x y).
+    + intro r.
+      destruct r as [a r].
+      destruct r as [b r].
+      snrapply path_universe_uncurried.
+      symmetry.
+      snrapply Build_Equiv.
+      * exact (identity_zigzag_concatPQinf R' x b a r).
+      * exact (isequiv_identity_zigzag_concatinf R' x b a r).
+  - intro r.
+    destruct r as [a r].
+    destruct r as [b r].
+    snrapply path_forall.
+    
+
+
+      

--- a/theories/PushoutPath/PushoutPath.v
+++ b/theories/PushoutPath/PushoutPath.v
@@ -155,163 +155,21 @@ Section Sequence.
 
 End Sequence.
 
-Definition identity_zigzag_Pinf {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) : Type := 
+Section Colimit.
+  Context {A B : Type} (R : A -> B -> Type) (a0 : A).
+
+Definition identity_zigzag_Pinf (a : A) : Type := 
   Colimit (identity_zigzag_P_seq R a0 a).
 
-Definition identity_zigzag_Qinf {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (b : B) : Type := 
+Definition identity_zigzag_Qinf (b : B) : Type :=
   Colimit (identity_zigzag_Q_seq R a0 b).
 
-Definition identity_zigzag_Pswap {A : Type} {B : Type} (R : A -> B -> Type) 
-  (a0 : A) (a : A) (t : nat) 
-  : (identity_zigzag_P R a0 a t) <~> (identity_zigzag_P R a a0 t).
-Proof.
-  induction t.
-  + simpl.
-    snrapply Build_Equiv.
-    2: exact (isequiv_path_inverse a0 a).
-  + simpl.
-    snrapply Build_Equiv.
-Admitted.
+  Context {a : A} {b : B} (r : R a b) `{Funext}.
 
-Definition identity_zigzag_concatQPinf `{Funext} {A : Type} {B : Type} 
-  (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) 
-  : (identity_zigzag_Qinf R a0 b) -> (identity_zigzag_Pinf R a0 a) := 
-  functor_colimit (identity_zigzag_seq_concatQP R a0 a b r) _ _.
+Definition identity_zigzag_concatQPinf
+  : (identity_zigzag_Qinf b) -> (identity_zigzag_Pinf a)
+  := functor_colimit (identity_zigzag_concatQP_seq R a0 r) _ _.
 
-Definition identity_zigzag_concatPQinf `{Funext} {A : Type} {B : Type} 
-  (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) 
-  : (identity_zigzag_Pinf R a0 a) -> (identity_zigzag_Qinf R a0 b) := 
-  (colim_succ_seq_to_colim_seq _)
-  o (functor_colimit (identity_zigzag_seq_concatPQ R a0 a b r) _ _ ).
-
-Section Death.
-  Context `{Funext} {A : Type} {B : Type} (R : A -> B -> Type) (a0 : A) 
-    (a : A) (b : B) (r : R a b).
-
-  Check (identity_zigzag_concatPQinf).
-
-End Death.
-
-Definition identity_zigzag_concatinf_retr `{Univalence} {A : Type} {B : Type} 
-  (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) 
-  : (identity_zigzag_concatPQinf R a0 a b r) 
-    o (identity_zigzag_concatQPinf R a0 a b r) 
-    == idmap.
-Proof.
-  snrapply Colimit_ind.
-  - simpl.
-    intros t p.
-    transitivity (inj (identity_zigzag_Q_seq R a0 b) (S t) 
-      (identity_zigzag_concatPQ R a0 a b r t (identity_zigzag_concatQP R a0 a b r t p))).
-    + reflexivity.
-    + transitivity (inj (identity_zigzag_Q_seq R a0 b) (S t) 
-      (identity_zigzag_iotaQ R a0 b t p)).
-      * apply ap.
-        exact (identity_zigzag_concatQPQ R a0 a b r t p).
-      * apply (glue (identity_zigzag_Q_seq R a0 b)).
-  - intros t n q p.
-    destruct q.
-    simpl.
-    admit.
-Admitted.
-
-Definition identity_zigzag_concatinf_sec `{Univalence} {A : Type} {B : Type}
-  (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) 
-  : (identity_zigzag_concatQPinf R a0 a b r) 
-    o (identity_zigzag_concatPQinf R a0 a b r) 
-    == idmap.
-Proof.
-Admitted.
-
-Definition isequiv_identity_zigzag_concatinf `{Univalence} {A : Type} 
-  {B : Type} (R : A -> B -> Type) (a0 : A) (a : A) (b : B) (r : R a b) 
-  : IsEquiv (identity_zigzag_concatPQinf R a0 a b r).
-Proof.
-  snrapply isequiv_adjointify.
-  2: exact (identity_zigzag_concatinf_retr R a0 a b r).
-  exact (identity_zigzag_concatinf_sec R a0 a b r).
-Defined.
-
-Definition relation_type {A : Type} {B : Type} (R : A -> B -> Type) 
-  : Type := { a : A | { b : B | R a b}}.
-
-Definition relation_pr1 {A: Type} {B : Type} (R : A -> B -> Type) 
-  : (relation_type R) -> A := pr1.
-
-Definition relation_pr2 {A: Type} {B : Type} (R : A -> B -> Type) 
-  : (relation_type R) -> B.
-Proof.
-  intro a.
-  destruct a as [a b].
-  exact (pr1 b).
-Defined.
-
-Definition relation_flip {A : Type} {B : Type} (R : A -> B -> Type) 
-  : forall (b : B)  (a : A), Type.
-Proof.
-  intros b a.
-  exact (R a b).
-Defined.
-
-Definition Pushout_relation {A : Type} {B : Type} (R : A -> B -> Type) : Type.
-Proof.
-  snrapply Pushout.
-  - exact (relation_type R).
-  - exact A.
-  - exact B.
-  - intro a.
-    destruct a as [a _].
-    exact a.
-  - intro a.
-    destruct a as [a [b r]].
-    exact b.
-Defined.
-
-Definition identity_zigzag_family `{Univalence} {A : Type} {B : Type} 
-  (R : A -> B -> Type) : (Pushout_relation R) -> (Pushout_relation R) -> Type.
-Proof.
-  snrapply Pushout_rec.
-  - intro x.
-    snrapply Pushout_rec.
-    + intro y.
-      exact (identity_zigzag_Pinf R x y).
-    + intro y.
-      exact (identity_zigzag_Qinf R x y).
-    + intro r.
-      destruct r as [a [b r]].
-      snrapply path_universe_uncurried.
-      snrapply Build_Equiv.
-      * exact (identity_zigzag_concatPQinf R x a b r).
-      * exact (isequiv_identity_zigzag_concatinf R x a b r).
-  - intro x.
-    pose (R' := (relation_flip R)).
-    snrapply Pushout_rec.
-    + intro y.
-      exact (identity_zigzag_Qinf R' x y).
-    + intro y.
-      exact (identity_zigzag_Pinf R' x y).
-    + intro r.
-      destruct r as [a [b r]].
-      snrapply path_universe_uncurried.
-      symmetry.
-      snrapply Build_Equiv.
-      * exact (identity_zigzag_concatPQinf R' x b a r).
-      * exact (isequiv_identity_zigzag_concatinf R' x b a r).
-  - intro r.
-    destruct r as [a [b r]].
-    snrapply path_forall.
-    snrapply Pushout_ind.
-    + intro a'.
-      simpl.
-
-      
-
-
-
-
-    
-
-
-      
+Definition identity_zigzag_concatPQinf 
+  : (identity_zigzag_Pinf a) -> (identity_zigzag_Qinf b)
+  := (colim_succ_seq_to_colim_seq _) o (functor_colimit (identity_zigzag_concatPQ_seq R a0 r) _ _ ).


### PR DESCRIPTION
Hi Dan,
your idea of showing that (cocone_precompose (seq_to_succ_seq A)) is an equivalence simplified everything by a big margin. I was able to prove that the maps I wanted to be equivalences are identities.

I'm not so sure if I should touch this code that much more, I think it is better that I get back to helping Ben with what he is doing right now. However, everything that is inside Section Is_Equiv_colim_succ_seq_to_seq_map can be generalized, and then possibly moved to Colimits.v. This should be very easy.

Another thing is that the 2-out-of-6 property is kind of redundant now, as the equivalences in question are identities. I can instead use isequiv_biinv to build the equivalence. However, I'm a little lazy, and hasn't changed this part of the code.

My naming schemes could also use a little work (we're all looking at you two_out_of_six).

All in all, I'm kinda unsure how useful this piece of code will be for us, so it might just be good to generalize what I can, so it isn't all for naught.