### PR TITLE
Colimit: generalize functor_Colimit_homotopy

### DIFF
--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -210,9 +210,6 @@ Proof.
   (* The proof is very similar to the proof of [functor_coeq_homotopy], but it's not clear if we can easily reuse that here. We'd have to redefine [functor_Colimit] using [functor_coeq], and that is more awkward. *)
   snrapply Colimit_ind.
   - intros i x; simpl.
-    unfold functor_Colimit_half.
-    unfold cocone_postcompose_inv.
-    simpl.
     apply ap, h_obj.
   - intros i j g x; simpl.
     Open Scope long_path_scope.
@@ -222,11 +219,10 @@ Proof.
     lhs nrapply concat_pp_p.
     apply moveR_Vp.
     rewrite ! concat_p_pp.
-    rewrite <- 2 (ap_pp (HQ j)).
+    rewrite <- 2 ap_pp.
     rewrite h_comm.
     rewrite concat_pp_V.
     rewrite <- ap_compose.
-    simpl.
     exact (concat_Ap (legs_comm HQ i j g) (h_obj i x))^.
     Close Scope long_path_scope.
 Defined.

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -183,23 +183,36 @@ Global Instance iscolimit_colimit `{Funext} {G : Graph} (D : Diagram G)
 
 (** We will capitalize [Colimit] to indicate that these definitions relate to the concrete colimit defined above.  Below, we will also get functoriality for abstract colimits, without the capital C.  However, to apply those results to the concrete colimit uses [iscolimit_colimit], which requires [Funext], so it is also useful to give direct proofs of some facts. *)
 
-Definition functor_Colimit {G : Graph} {D1 D2 : Diagram G} (m : DiagramMap D1 D2)
-  : Colimit D1 -> Colimit D2.
+(** Any diagram map [m : D1 => D2] induces a map between the canonical colimit of [D1] and any cocone over [D2]. *)
+
+Definition functor_Colimit_half {G : Graph} {D1 D2 : Diagram G} (m : DiagramMap D1 D2) {Q} (HQ : Cocone D2 Q)
+  : Colimit D1 -> Q.
 Proof.
   apply Colimit_rec.
-  refine (cocone_precompose m (cocone_colimit D2)).
+  refine (cocone_precompose m HQ).
 Defined.
 
+(** And between the canonical colimits. *)
+
+Definition functor_Colimit {G : Graph} {D1 D2 : Diagram G} (m : DiagramMap D1 D2)
+  : Colimit D1 -> Colimit D2
+  := functor_Colimit_half m (cocone_colimit D2).
+
+(** A homotopy between diagram maps [m1, m2 : D1 => D2] gives a homotopy between their colimits. *)
+
 Definition functor_Colimit_homotopy {G : Graph} {D1 D2 : Diagram G}
-  {m1 m2 : DiagramMap D1 D2} (h_obj : forall i, m1 i == m2 i)
+  {m1 m2 : DiagramMap D1 D2} {Q} (HQ : Cocone D2 Q) (h_obj : forall i, m1 i == m2 i)
   (h_comm : forall i j (g : G i j) x,
       DiagramMap_comm m1 g x @ h_obj j (D1 _f g x)
       = ap (D2 _f g) (h_obj i x) @ DiagramMap_comm m2 g x)
-  : functor_Colimit m1 == functor_Colimit m2.
+  : functor_Colimit_half m1 HQ == functor_Colimit_half m2 HQ.
 Proof.
   (* The proof is very similar to the proof of [functor_coeq_homotopy], but it's not clear if we can easily reuse that here. We'd have to redefine [functor_Colimit] using [functor_coeq], and that is more awkward. *)
   snrapply Colimit_ind.
   - intros i x; simpl.
+    unfold functor_Colimit_half.
+    unfold cocone_postcompose_inv.
+    simpl.
     apply ap, h_obj.
   - intros i j g x; simpl.
     Open Scope long_path_scope.
@@ -209,13 +222,14 @@ Proof.
     lhs nrapply concat_pp_p.
     apply moveR_Vp.
     rewrite ! concat_p_pp.
-    rewrite <- 2 ap_pp.
+    rewrite <- 2 (ap_pp (HQ j)).
     rewrite h_comm.
     rewrite concat_pp_V.
     rewrite <- ap_compose.
-    exact (concat_Ap (colimp i j g) (h_obj i x))^.
+    simpl.
+    exact (concat_Ap (legs_comm HQ i j g) (h_obj i x))^.
     Close Scope long_path_scope.
-Qed.
+Defined.
 
 (** ** Functoriality of abstract colimits *)
 


### PR DESCRIPTION
I've generalized `functor_Colimit_homotopy` slightly for the situation we need: the domain is the canonical colimit of D1 and the codomain can be any cocone over D2. The same proof goes through with some renaming and a bit more handholding. I've also changed the `Qed` to `Defined` so that it computes to `ap (legs HQ i) (h_obj i x)` on `colim i x`.