### PR TITLE
Flattening lemma for colimits

### DIFF
--- a/theories/Colimits/Coeq.v
+++ b/theories/Colimits/Coeq.v
@@ -199,18 +199,20 @@ Definition functor_coeq_homotopy {B A f g B' A' f' g'}
 : functor_coeq h k p q == functor_coeq h' k' p' q'.
 Proof.
   refine (Coeq_ind _ (fun a => ap coeq (s a)) _); cbn; intros b.
-  refine (transport_paths_FlFr (cglue b) _ @ _).
-  rewrite concat_pp_p; apply moveR_Vp.
+  apply transport_paths_FlFr'.
   rewrite !functor_coeq_beta_cglue.
   Open Scope long_path_scope.
+  rewrite 2 ap_V.
   rewrite !concat_p_pp.
+  apply moveL_pV.
   rewrite <- (ap_pp (@coeq _ _ f' g') (s (f b)) (p' b)).
-  rewrite u, ap_pp, !concat_pp_p; apply whiskerL; rewrite !concat_p_pp.
-  rewrite ap_V; apply moveR_pV.
-  rewrite !concat_pp_p, <- (ap_pp (@coeq _ _ f' g') (s (g b)) (q' b)).
-  rewrite v, ap_pp, ap_V, concat_V_pp.
-  rewrite <- !ap_compose.
-  exact (concat_Ap (@cglue _ _ f' g') (r b)).
+  rewrite u, ap_pp.
+  rewrite !concat_pp_p; apply whiskerL.
+  rewrite <- (ap_pp (@coeq _ _ f' g') (s (g b)) (q' b)).
+  rewrite v, ap_pp.
+  rewrite concat_V_pp.
+  rewrite <- 2 ap_compose.
+  exact (concat_Ap (@cglue _ _ f' g') (r b))^.
   Close Scope long_path_scope.
 Qed.
 

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -182,7 +182,45 @@ Defined.
 Global Instance iscolimit_colimit `{Funext} {G : Graph} (D : Diagram G)
   : IsColimit D (Colimit D) := Build_IsColimit _ (unicocone_colimit D).
 
-(** * Functoriality of colimits *)
+(** ** Functoriality of concrete colimits *)
+
+(** We will capitalize [Colimit] to indicate that these definitions relate to the concrete colimit defined above.  Below, we will also get functoriality for abstract colimits, without the capital C.  However, to apply those results to the concrete colimit uses [iscolimit_colimit], which requires [Funext], so it is also useful to give direct proofs of some facts. *)
+
+Definition functor_Colimit {G : Graph} {D1 D2 : Diagram G} (m : DiagramMap D1 D2)
+  : Colimit D1 -> Colimit D2.
+Proof.
+  apply Colimit_rec.
+  refine (cocone_precompose m (cocone_colimit D2)).
+Defined.
+
+Definition functor_Colimit_homotopy {G : Graph} {D1 D2 : Diagram G}
+  {m1 m2 : DiagramMap D1 D2} (h_obj : forall i, m1 i == m2 i)
+  (h_comm : forall i j (g : G i j) x,
+      DiagramMap_comm m1 g x @ h_obj j (D1 _f g x)
+      = ap (D2 _f g) (h_obj i x) @ DiagramMap_comm m2 g x)
+  : functor_Colimit m1 == functor_Colimit m2.
+Proof.
+  (* The proof is very similar to the proof of [functor_coeq_homotopy], but it's not clear if we can easily reuse that here. We'd have to redefine [functor_Colimit] using [functor_coeq], and that is more awkward. *)
+  snrapply Colimit_ind.
+  - intros i x; simpl.
+    apply ap, h_obj.
+  - intros i j g x; simpl.
+    Open Scope long_path_scope.
+    nrapply (transport_paths_FlFr' (colimp i j g x)); simpl.
+    rewrite 2 Colimit_rec_beta_colimp; simpl.
+    rewrite ap_V.
+    lhs nrapply concat_pp_p.
+    apply moveR_Vp.
+    rewrite ! concat_p_pp.
+    rewrite <- 2 ap_pp.
+    rewrite h_comm.
+    rewrite concat_pp_V.
+    rewrite <- ap_compose.
+    exact (concat_Ap (colimp i j g) (h_obj i x))^.
+    Close Scope long_path_scope.
+Qed.
+
+(** ** Functoriality of abstract colimits *)
 
 Section FunctorialityColimit.
 

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -12,6 +12,8 @@ Generalizable All Variables.
 
 (** * Colimits *)
 
+(** ** Abstract definition *)
+
 (** A colimit is the extremity of a cocone. *)
 
 Class IsColimit `(D: Diagram G) (Q: Type) := {
@@ -33,21 +35,16 @@ Definition cocone_postcompose_inv `{D: Diagram G} {Q X}
   (H : IsColimit D Q) (C' : Cocone D X) : Q -> X
   := @equiv_inv _ _ _ (iscolimit_unicocone H X) C'.
 
-(** * Existence of colimits *)
+(** ** Existence of colimits *)
 
-(** Whatever the diagram considered, there exists a colimit of it. The existence is given by the HIT [colimit]. *)
-
-(** ** Definition of the HIT 
+(** Every diagram has a colimit.  It could be described as the following HIT
 <<
   HIT Colimit {G : Graph} (D : Diagram G) : Type :=
   | colim : forall i, D i -> Colimit D
   | colimp : forall i j (f : G i j) (x : D i) : colim j (D _f f x) = colim i x
   .
 >>
-*)
-
-(** A colimit is just the coequalizer of the source and target maps of the diagram. *)
-(** The source type in the coequalizer ought to be:
+but we instead describe it as the coequalizer of the source and target maps of the diagram.  The source type in the coequalizer ought to be:
 <<
 {x : sig D & {y : sig D & {f : G x.1 y.1 & D _f f x.2 = y.2}}}
 >>
@@ -245,7 +242,7 @@ Section FunctorialityColimit.
     apply cocone_postcompose_equiv_universality, HQ.
   Defined.
 
-  (** A diagram map [m] : [D1] => [D2] induces a map between any two colimits of [D1] and [D2]. *)
+  (** A diagram map [m : D1 => D2] induces a map between any two colimits of [D1] and [D2]. *)
 
   Definition functor_colimit {D1 D2 : Diagram G} (m : DiagramMap D1 D2)
     {Q1 Q2} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
@@ -260,9 +257,7 @@ Section FunctorialityColimit.
       = cocone_postcompose HQ1 (functor_colimit m HQ1 HQ2)
     := (eisretr (cocone_postcompose HQ1) _)^.
 
-  (** ** Colimits of equivalent diagrams *)
-
-  (** Now we have than two equivalent diagrams have equivalent colimits. *)
+  (** Equivalent diagrams have equivalent colimits. *)
 
   Context {D1 D2 : Diagram G} (m : D1 ~d~ D2) {Q1 Q2}
     (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2).
@@ -309,7 +304,7 @@ Section FunctorialityColimit.
 
 End FunctorialityColimit.
 
-(** * Unicity of colimits *)
+(** ** Unicity of colimits *)
 
 (** A particuliar case of the functoriality result is that all colimits of a diagram are equivalent (and hence equal in presence of univalence). *)
 
@@ -321,7 +316,7 @@ Proof.
   srapply (Build_diagram_equiv (diagram_idmap D)).
 Defined.
 
-(** * Colimits are left adjoint to constant diagram *)
+(** ** Colimits are left adjoint to constant diagram *)
 
 Theorem colimit_adjoint `{Funext} {G : Graph} {D : Diagram G} {C : Type}
   : (Colimit D -> C) <~> DiagramMap D (diagram_const C).

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -210,9 +210,6 @@ Proof.
   (* The proof is very similar to the proof of [functor_coeq_homotopy], but it's not clear if we can easily reuse that here. We'd have to redefine [functor_Colimit] using [functor_coeq], and that is more awkward. *)
   snrapply Colimit_ind.
   - intros i x; simpl.
-    unfold functor_Colimit_half.
-    unfold cocone_postcompose_inv.
-    simpl.
     apply ap, h_obj.
   - intros i j g x; simpl.
     Open Scope long_path_scope.
@@ -222,11 +219,10 @@ Proof.
     lhs nrapply concat_pp_p.
     apply moveR_Vp.
     rewrite ! concat_p_pp.
-    rewrite <- 2 (ap_pp (HQ j)).
+    rewrite <- 2 ap_pp.
     rewrite h_comm.
     rewrite concat_pp_V.
     rewrite <- ap_compose.
-    simpl.
     exact (concat_Ap (legs_comm HQ i j g) (h_obj i x))^.
     Close Scope long_path_scope.
 Defined.

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -183,23 +183,36 @@ Global Instance iscolimit_colimit `{Funext} {G : Graph} (D : Diagram G)
 
 (** We will capitalize [Colimit] to indicate that these definitions relate to the concrete colimit defined above.  Below, we will also get functoriality for abstract colimits, without the capital C.  However, to apply those results to the concrete colimit uses [iscolimit_colimit], which requires [Funext], so it is also useful to give direct proofs of some facts. *)
 
-Definition functor_Colimit {G : Graph} {D1 D2 : Diagram G} (m : DiagramMap D1 D2)
-  : Colimit D1 -> Colimit D2.
+(** Any diagram map [m : D1 => D2] induces a map between the canonical colimit of [D1] and any cocone over [D2]. *)
+
+Definition functor_Colimit_half {G : Graph} {D1 D2 : Diagram G} (m : DiagramMap D1 D2) {Q} (HQ : Cocone D2 Q)
+  : Colimit D1 -> Q.
 Proof.
   apply Colimit_rec.
-  refine (cocone_precompose m (cocone_colimit D2)).
+  refine (cocone_precompose m HQ).
 Defined.
 
+(** And between the canonical colimits. *)
+
+Definition functor_Colimit {G : Graph} {D1 D2 : Diagram G} (m : DiagramMap D1 D2)
+  : Colimit D1 -> Colimit D2
+  := functor_Colimit_half m (cocone_colimit D2).
+
+(** A homotopy between diagram maps [m1, m2 : D1 => D2] gives a homotopy between their colimits. *)
+
 Definition functor_Colimit_homotopy {G : Graph} {D1 D2 : Diagram G}
-  {m1 m2 : DiagramMap D1 D2} (h_obj : forall i, m1 i == m2 i)
+  {m1 m2 : DiagramMap D1 D2} {Q} (HQ : Cocone D2 Q) (h_obj : forall i, m1 i == m2 i)
   (h_comm : forall i j (g : G i j) x,
       DiagramMap_comm m1 g x @ h_obj j (D1 _f g x)
       = ap (D2 _f g) (h_obj i x) @ DiagramMap_comm m2 g x)
-  : functor_Colimit m1 == functor_Colimit m2.
+  : functor_Colimit_half m1 HQ == functor_Colimit_half m2 HQ.
 Proof.
   (* The proof is very similar to the proof of [functor_coeq_homotopy], but it's not clear if we can easily reuse that here. We'd have to redefine [functor_Colimit] using [functor_coeq], and that is more awkward. *)
   snrapply Colimit_ind.
   - intros i x; simpl.
+    unfold functor_Colimit_half.
+    unfold cocone_postcompose_inv.
+    simpl.
     apply ap, h_obj.
   - intros i j g x; simpl.
     Open Scope long_path_scope.
@@ -209,13 +222,14 @@ Proof.
     lhs nrapply concat_pp_p.
     apply moveR_Vp.
     rewrite ! concat_p_pp.
-    rewrite <- 2 ap_pp.
+    rewrite <- 2 (ap_pp (HQ j)).
     rewrite h_comm.
     rewrite concat_pp_V.
     rewrite <- ap_compose.
-    exact (concat_Ap (colimp i j g) (h_obj i x))^.
+    simpl.
+    exact (concat_Ap (legs_comm HQ i j g) (h_obj i x))^.
     Close Scope long_path_scope.
-Qed.
+Defined.
 
 (** ** Functoriality of abstract colimits *)
 

--- a/theories/Diagrams/ConstantDiagram.v
+++ b/theories/Diagrams/ConstantDiagram.v
@@ -50,7 +50,14 @@ Section ConstantDiagram.
     1,2: intros[].
     1: srapply path_cocone.
     3: srapply path_DiagramMap.
-    1,3: reflexivity.
+    1: reflexivity.
+    2: {
+      snrapply exist.
+      - intro i; reflexivity.
+      - intros i j g x; cbn.
+        lhs refine (inv_V (DiagramMap_comm i j g x) @@ 1).
+        apply concat_p1_1p.
+    }
     all: cbn; intros; hott_simpl.
   Defined.
 

--- a/theories/Diagrams/ConstantDiagram.v
+++ b/theories/Diagrams/ConstantDiagram.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics Types.Paths.
 Require Import Cone.
 Require Import Cocone.
 Require Import Diagram.
@@ -29,36 +29,30 @@ Section ConstantDiagram.
   Definition diagram_const_functor_comp {A B C : Type}
     (f : A -> B) (g : B -> C)
     : diagram_const_functor (g o f)
-    = diagram_comp (diagram_const_functor g) (diagram_const_functor f).
-  Proof.
-    reflexivity.
-  Defined.
+      = diagram_comp (diagram_const_functor g) (diagram_const_functor f)
+    := idpath.
 
   Definition diagram_const_functor_idmap {A : Type}
-    : diagram_const_functor (idmap : A -> A) = diagram_idmap (diagram_const A).
-  Proof.
-    reflexivity.
-  Defined.
+    : diagram_const_functor (idmap : A -> A) = diagram_idmap (diagram_const A)
+    := idpath.
 
   Definition equiv_diagram_const_cocone `{Funext} (D : Diagram G) (X : Type)
     : DiagramMap D (diagram_const X) <~> Cocone D X.
   Proof.
     srapply equiv_adjointify.
+    (* The two functions are defined in parallel: *)
     1,2: intros [? w]; econstructor.
+    (* This reversal is a defect in the definition of [Cocone]. *)
     1,2: intros x y z z'; symmetry; revert x y z z'.
     1,2: exact w.
-    1,2: intros[].
-    1: srapply path_cocone.
-    3: srapply path_DiagramMap.
-    1: reflexivity.
-    2: {
-      snrapply exist.
-      - intro i; reflexivity.
-      - intros i j g x; cbn.
-        lhs refine (inv_V (DiagramMap_comm i j g x) @@ 1).
-        apply concat_p1_1p.
-    }
-    all: cbn; intros; hott_simpl.
+    (* The two homotopies are proved in parallel: *)
+    1,2: intros [].
+    1: srapply path_cocone; cbn.
+    3: srapply path_DiagramMap; snrefine (_; _); cbn.
+    1,3: reflexivity.
+    1,2: intros; cbn.
+    1,2: apply equiv_p1_1q.
+    1,2: apply inv_V.
   Defined.
 
   Definition equiv_diagram_const_cone `{Funext} (X : Type) (D : Diagram G)
@@ -75,6 +69,3 @@ Section ConstantDiagram.
   Defined.
 
 End ConstantDiagram.
-
-
-

--- a/theories/Diagrams/Diagram.v
+++ b/theories/Diagrams/Diagram.v
@@ -78,18 +78,31 @@ Section Diagram.
   Global Arguments DiagramMap_comm  [D1 D2] m [i j] f x : rename.
   Global Arguments Build_DiagramMap [D1 D2] _ _.
 
+  Definition DiagramMap_homotopy {D1 D2 : Diagram G}
+    (m1 m2 : DiagramMap D1 D2) : Type
+    := {h_obj : (forall i, m1 i == m2 i) & (forall i j (g : G i j) x,
+      DiagramMap_comm m1 g x @ h_obj j (D1 _f g x)
+      = ap (D2 _f g) (h_obj i x) @ DiagramMap_comm m2 g x)}.
+
+  Global Instance reflexive_DiagramMap_homotopy {D1 D2 : Diagram G} : Reflexive (@DiagramMap_homotopy D1 D2).
+  Proof.
+    intros m.
+    snrapply exist.
+    - intro i; reflexivity.
+    - intros i j g x; cbn.
+      apply concat_p1_1p.
+  Defined.
+
   (** [path_DiagramMap] says when two maps are equals (up to funext). *)
 
   Definition path_DiagramMap {D1 D2 : Diagram G}
-    {m1 m2 : DiagramMap D1 D2} (h_obj : forall i, m1 i == m2 i)
-    (h_comm : forall i j (g : G i j) x,
-      DiagramMap_comm m1 g x @ h_obj j (D1 _f g x)
-      = ap (D2 _f g) (h_obj i x) @ DiagramMap_comm m2 g x)
+    {m1 m2 : DiagramMap D1 D2} (h : DiagramMap_homotopy m1 m2)
     : m1 = m2.
   Proof.
     destruct m1 as [m1_obj m1_comm].
     destruct m2 as [m2_obj m2_comm].
     simpl in *.
+    destruct h as [h_obj h_comm].
     revert h_obj h_comm.
     set (E := (@equiv_functor_forall _
        G (fun i => m1_obj i = m2_obj i)
@@ -156,11 +169,11 @@ Section Diagram.
   Proof.
     destruct w as [[w_obj w_comm] is_eq_w]. simpl in *.
     set (we i := Build_Equiv _ _ _ (is_eq_w i)).
-    simple refine (path_DiagramMap _ _).
-    - exact (fun i => eisretr (we i)).
-    - simpl.
-      intros i j f x. apply (concatR (concat_p1 _)^).
-      apply (comm_square_inverse_is_retr (we i) (we j) _ x).
+    simple refine (path_DiagramMap _).
+    exists (fun i => eisretr (we i)).
+    simpl.
+    intros i j f x. apply (concatR (concat_p1 _)^).
+    apply (comm_square_inverse_is_retr (we i) (we j) _ x).
   Defined.
 
   Lemma diagram_inv_is_retraction {D1 D2 : Diagram G}
@@ -169,11 +182,11 @@ Section Diagram.
   Proof.
     destruct w as [[w_obj w_comm] is_eq_w]. simpl in *.
     set (we i := Build_Equiv _ _ _ (is_eq_w i)).
-    simple refine (path_DiagramMap _ _).
-    - exact (fun i => eissect (we i)).
-    - simpl.
-      intros i j f x. apply (concatR (concat_p1 _)^).
-      apply (comm_square_inverse_is_sect (we i) (we j) _ x).
+    simple refine (path_DiagramMap _).
+    exists (fun i => eissect (we i)).
+    simpl.
+    intros i j f x. apply (concatR (concat_p1 _)^).
+    apply (comm_square_inverse_is_sect (we i) (we j) _ x).
   Defined.
 
   (** The equivalence of diagram is an equivalence relation. *)

--- a/theories/Diagrams/Diagram.v
+++ b/theories/Diagrams/Diagram.v
@@ -169,10 +169,11 @@ Section Diagram.
   Proof.
     destruct w as [[w_obj w_comm] is_eq_w]. simpl in *.
     set (we i := Build_Equiv _ _ _ (is_eq_w i)).
-    simple refine (path_DiagramMap _).
+    apply path_DiagramMap.
     exists (fun i => eisretr (we i)).
     simpl.
-    intros i j f x. apply (concatR (concat_p1 _)^).
+    intros i j f x.
+    rhs nrapply concat_p1.
     apply (comm_square_inverse_is_retr (we i) (we j) _ x).
   Defined.
 
@@ -182,10 +183,11 @@ Section Diagram.
   Proof.
     destruct w as [[w_obj w_comm] is_eq_w]. simpl in *.
     set (we i := Build_Equiv _ _ _ (is_eq_w i)).
-    simple refine (path_DiagramMap _).
+    apply path_DiagramMap.
     exists (fun i => eissect (we i)).
     simpl.
-    intros i j f x. apply (concatR (concat_p1 _)^).
+    intros i j f x.
+    rhs nrapply concat_p1.
     apply (comm_square_inverse_is_sect (we i) (we j) _ x).
   Defined.
 
@@ -199,9 +201,11 @@ Section Diagram.
 
   Global Instance transitive_diagram_equiv : Transitive diagram_equiv | 1.
   Proof.
-  simple refine (fun D1 D2 D3 m1 m2 =>
-                   Build_diagram_equiv (diagram_comp m2 m1) _).
-  simpl. intros i; apply isequiv_compose';[apply m1 | apply m2].
+    intros D1 D2 D3 m1 m2.
+    nrapply (Build_diagram_equiv (diagram_comp m2 m1)).
+    intros i.
+    simpl.
+    apply isequiv_compose'; [apply m1 | apply m2].
   Defined.
 End Diagram.
 

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -222,6 +222,18 @@ Definition path_sigma_pp_pp' {A : Type} (P : A -> Type)
     = path_sigma' P p1 q1 @ path_sigma' P p2 q2
   := @path_sigma_pp_pp A P (u1;u2) (v1;v2) (w1;w2) p1 q1 p2 q2.
 
+Definition path_sigma_p1_pp' {A : Type} (P : A -> Type)
+  {u1 v1} {u2 : P u1} {v2 w2 : P v1}
+  (p1 : u1 = v1) (q1 : p1 # u2 = v2) (q2 : v2 = w2)
+  : path_sigma' P p1 (q1 @ q2)
+    = path_sigma' P p1 q1 @ path_sigma' P 1 q2.
+Proof.
+  destruct q2. cbn.
+  rhs nrapply concat_p1.
+  f_ap.
+  nrapply concat_p1.
+Defined.
+
 Definition path_sigma_p1_1p' {A : Type} (P : A -> Type)
   {u1 v1 : A} {u2 : P u1} {v2 : P v1}
   (p : u1 = v1) (q : p # u2 = v2)


### PR DESCRIPTION
We reprove the flattening lemma for colimits using descent. This particular method has the perk of being the same method as used for graph quotients, coequalizers, and pushouts. A lot of the proofs involved in the flattening lemma simplifies a lot, and become completely analogous to the other three cases. The only major difference appears first after we're done with proving all the necessary lemmata, and we're proving the flattening lemma.

This approach suffers from some of the same slowness problems as the first proof. The functions are in general a lot faster, but more parts are acting slowly.

With this approach we also get a characterization of path spaces of colimits basicly for free, using Kraus-von Raumer.

There are still a couple of cleanups that can be done. I think there are some overlap with the Descent section and some files in the Diagrams subdirectory.

(This work is done on an old version of some of the files found here. Consider only the parts after descent, as that are the only relevant parts.) 