### PR TITLE
Defining properties of maxima and minima, Lemmas for the take operation in lists, lists from sequences.

### DIFF
--- a/theories/Algebra/Rings/Vector.v
+++ b/theories/Algebra/Rings/Vector.v
@@ -40,7 +40,6 @@ Proof.
   snrapply nth'_Build_list.
 Defined.
 
-
 Global Instance istrunc_vector@{i} (A : Type@{i}) (n : nat) k `{IsTrunc k.+2 A}
   : IsTrunc k.+2 (Vector A n).
 Proof.

--- a/theories/Algebra/Rings/Vector.v
+++ b/theories/Algebra/Rings/Vector.v
@@ -23,30 +23,23 @@ Definition Vector@{i|} (A : Type@{i}) (n : nat) : Type@{i}
 
 Definition Build_Vector (A : Type) (n : nat)
   (f : forall (i : nat), (i < n)%nat -> A)
-  : Vector A n. 
-Proof.
-  exists (list_map (fun '(i; Hi) => f i Hi) (seq' n)).
-  lhs nrapply length_list_map.
-  apply length_seq'.
-Defined.
+  : Vector A n
+  := (Build_list n f; length_Build_list n f).
 
 (** *** Projections *)
 
 Definition entry {A : Type} {n : nat} (v : Vector A n) i {Hi : (i < n)%nat} : A
   := nth' (pr1 v) i ((pr2 v)^ # Hi).
 
-(** *** Basic properties *) 
+(** *** Basic properties *)
 
 Definition entry_Build_Vector {A : Type} {n}
   (f : forall (i : nat), (i < n)%nat -> A) i {Hi : (i < n)%nat}
   : entry (Build_Vector A n f) i = f i Hi.
 Proof.
-  snrefine (nth'_list_map _ _ _ (_^ # Hi) _ @ _).
-  1: nrapply length_seq'.
-  snrapply ap011D.
-  1: nrapply nth'_seq'.
-  rapply path_ishprop. 
+  snrapply nth'_Build_list.
 Defined.
+
 
 Global Instance istrunc_vector@{i} (A : Type@{i}) (n : nat) k `{IsTrunc k.+2 A}
   : IsTrunc k.+2 (Vector A n).
@@ -103,7 +96,7 @@ Section VectorAddition.
     rewrite 4 entry_Build_Vector.
     apply associativity.
   Defined.
-  
+
   Definition commutative_vector_plus : Commutative vector_plus.
   Proof.
     intros v1 v2; apply path_vector; intros i Hi.
@@ -171,7 +164,7 @@ Section VectorScale.
 
   Definition vector_lact (r : R) : Vector M n -> Vector M n
     := vector_map (lact r).
-  
+
   Definition left_heterodistribute_vector_lact_plus
     : LeftHeteroDistribute vector_lact vector_plus vector_plus.
   Proof.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -665,8 +665,10 @@ Defined.
 Definition take_take_min {A : Type} {m n : nat} (l : list A)
   : take n (take m l) = take (nat_min n m) l.
 Proof.
-  revert n m l; induction n, m; intro l.
-  1-3: reflexivity.
+  induction n in m, l |- *.
+  1: reflexivity.
+  destruct m.
+  1: reflexivity.
   destruct l as [|a l'].
   1: by rewrite !take_nil.
   cbn. apply ap, IHn.
@@ -685,10 +687,10 @@ Definition take_app {A : Type} {n : nat} (l1 l2 : list A) (hn : n <= length l1)
 Proof.
   induction n in l1, l2, hn |- *.
   - reflexivity.
-  - induction l1 as [|a l1 IHl1].
+  - destruct l1 as [|a l1].
     + contradiction (not_lt_zero_r _ hn).
     + cbn.
-      apply ap, IHn, (_ hn).
+      apply ap, IHn, leq_pred', hn.
 Defined.
 
 (** *** Remove *)
@@ -980,9 +982,9 @@ Definition entry_list_restrict {A : Type} (s : nat -> A) (n : nat)
   {i : nat} (Hi : i < n)
   : nth' (list_restrict s n) i ((list_restrict_length s n)^ # Hi) = s i.
 Proof.
-  lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
+  unshelve lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
+  - nrapply length_seq'.
   - exact (ap s (nth'_seq' _ _ _)).
-  Unshelve. nrapply length_seq'.
 Defined.
 
 (** ** Repeat *)

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -970,8 +970,9 @@ Proof.
 Defined.
 
 Definition nth'_Build_list {A : Type} {n : nat}
-  (f : forall (i : nat), (i < n) -> A) {i : nat} (Hi : (i < n))
-  : nth' (Build_list n f) i ((length_Build_list n f)^ # Hi) = f i Hi.
+  (f : forall (i : nat), (i < n) -> A) {i : nat} (Hi : i < n)
+  (Hi' : i < length (Build_list n f))
+  : nth' (Build_list n f) i Hi' = f i Hi.
 Proof.
   unshelve lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
   1: nrapply length_seq'.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -15,12 +15,11 @@ Local Set Polymorphic Inductive Cumulativity.
 
 Local Open Scope list_scope.
 Local Open Scope nat_scope.
-Local Open Scope type_scope.
 
 (** ** Length *)
 
 (** A list of length zero must be the empty list. *)
-Definition length_0 {A : Type} (l : list A) (H : length l = 0%nat)
+Definition length_0 {A : Type} (l : list A) (H : length l = 0)
   : l = nil.
 Proof.
   destruct l.
@@ -75,7 +74,7 @@ Defined.
 
 (** The length of a concatenated list is the sum of the lengths of the two lists. *)
 Definition length_app {A : Type} (l l' : list A)
-  : length (l ++ l') = (length l + length l')%nat.
+  : length (l ++ l') = length l + length l'.
 Proof.
   induction l as [|a l IHl] using list_ind.
   1: reflexivity.
@@ -138,7 +137,7 @@ Defined.
 
 (** An element of a mapped list is equal to the function applied to some element of the original list. *)
 Definition inlist_map' {A B : Type} (f : A -> B) (l : list A) (x : B)
-  : InList x (list_map f l) -> { y : A & (f y = x) * InList y l }.
+  : InList x (list_map f l) -> { y : A & prod (f y = x) (InList y l) }.
 Proof.
   induction l as [|y l IHl].
   1: contradiction.
@@ -244,7 +243,7 @@ Defined.
 
 (** The length of [reverse_acc] is the sum of the lengths of the two lists. *)
 Definition length_reverse_acc@{i|} {A : Type@{i}} (acc l : list A)
-  : length (reverse_acc acc l) = (length acc + length l)%nat.
+  : length (reverse_acc acc l) = length acc + length l.
 Proof.
   symmetry.
   induction l as [|x l IHl] in acc |- * using list_ind@{i i}.
@@ -331,7 +330,7 @@ Defined.
 
 (** A variant of [nth] that returns an element of the list and a proof that it is the [n]-th element. *)
 Definition nth_lt@{i|} {A : Type@{i}} (l : list A) (n : nat)
-  (H : (n < length l)%nat)
+  (H : n < length l)
   : { x : A & nth l n = Some x }.
 Proof.
   induction l as [|a l IHa] in n, H |- * using list_ind@{i i}.
@@ -344,11 +343,11 @@ Proof.
 Defined.
 
 (** A variant of [nth] that always returns an element when we know that the index is in the list. *)
-Definition nth' {A : Type} (l : list A) (n : nat) (H : (n < length l)%nat) : A
+Definition nth' {A : Type} (l : list A) (n : nat) (H : n < length l) : A
   := pr1 (nth_lt l n H).
 
 (** The [nth'] element doesn't depend on the proof that [n < length l]. *)
-Definition nth'_nth' {A} (l : list A) (n : nat) (H H' : (n < length l)%nat)
+Definition nth'_nth' {A} (l : list A) (n : nat) (H H' : n < length l)
   : nth' l n H = nth' l n H'.
 Proof.
   apply ap, path_ishprop.
@@ -371,7 +370,7 @@ Defined.
 
 (** The [nth'] element of a list is in the list. *)
 Definition inlist_nth'@{i|} {A : Type@{i}} (l : list A) (n : nat)
-  (H : (n < length l)%nat)
+  (H : n < length l)
   : InList (nth' l n H) l.
 Proof.
   induction l as [|a l IHa] in n, H |- * using list_ind@{i i}.
@@ -383,7 +382,7 @@ Proof.
 Defined.
 
 (** The [nth'] element of a list is the same as the one given by [nth]. *)
-Definition nth_nth' {A} (l : list A) (n : nat) (H : (n < length l)%nat)
+Definition nth_nth' {A} (l : list A) (n : nat) (H : n < length l)
   : nth l n = Some (nth' l n H).
 Proof.
   exact (nth_lt l n H).2.
@@ -391,7 +390,7 @@ Defined.
 
 (** The [nth'] element of a [cons] indexed at [n.+1] is the same as the [nth'] element of the tail indexed at [n]. *)
 Definition nth'_cons {A : Type} (l : list A) (n : nat) (x : A)
-  (H : (n < length l)%nat) (H' : (n.+1 < length (x :: l))%nat)
+  (H : n < length l) (H' : n.+1 < length (x :: l))
   : nth' (x :: l) n.+1 H' = nth' l n H.
 Proof.
   apply isinj_some.
@@ -403,19 +402,19 @@ Defined.
 (** The index of an element in a list is the [n] such that the [nth'] element is the element. *)
 Definition index_of@{i|} {A : Type@{i}} (l : list A) (x : A)
   : InList x l
-    -> sig@{Set i} (fun n : nat => { H : (n < length l)%nat & nth' l n H = x }).
+    -> sig@{Set i} (fun n : nat => { H : n < length l & nth' l n H = x }).
 Proof.
   induction l as [|a l IHl] using list_ind@{i i}.
   1: intros x'; destruct x'.
   intros [| i].
   - revert a p.
     snrapply paths_ind_r@{i i}.
-    snrefine (exist@{i i} _ 0%nat _).
+    snrefine (exist@{i i} _ 0 _).
     snrefine (exist _ _ idpath).
     apply leq_succ.
     exact _.
   - destruct (IHl i) as [n [H H']].
-    snrefine (exist@{i i} _ n.+1%nat _).
+    snrefine (exist@{i i} _ n.+1 _).
     snrefine (_; _); cbn.
     1: apply leq_succ, H.
     refine (_ @ H').
@@ -436,8 +435,8 @@ Defined.
 
 (** The [nth'] element of a [list_map] is the function applied to the [nth'] element of the original list. *)
 Definition nth'_list_map@{i j|} {A : Type@{i}} {B : Type@{j}}
-  (f : A -> B) (l : list A) (n : nat) (H : (n < length l)%nat)
-  (H' : (n < length (list_map f l))%nat)
+  (f : A -> B) (l : list A) (n : nat) (H : n < length l)
+  (H' : n < length (list_map f l))
   : nth' (list_map f l) n H' = f (nth' l n H).
 Proof.
   induction l as [|a l IHl] in n, H, H' |- * using list_ind@{i j}.
@@ -450,8 +449,8 @@ Defined.
 (** The [nth'] element of a [list_map2] is the function applied to the [nth'] elements of the original lists. The length of the two lists is required to be the same. *)
 Definition nth'_list_map2 {A B C : Type}
   (f : A -> B -> C) (l1 : list A) (l2 : list B)
-  (n : nat) defl defr (H : (n < length l1)%nat) (H' : (n < length l2)%nat)
-  (H'' : (n < length (list_map2 f defl defr l1 l2))%nat)
+  (n : nat) defl defr (H : n < length l1) (H' : n < length l2)
+  (H'' : n < length (list_map2 f defl defr l1 l2))
   (p : length l1 = length l2)
   : f (nth' l1 n H) (nth' l2 n H') = nth' (list_map2 f defl defr l1 l2) n H''.
 Proof.
@@ -472,7 +471,7 @@ Defined.
 
 (** The [nth'] element of a [repeat] is the repeated value. *)
 Definition nth'_repeat@{i|} {A : Type@{i}} (x : A) (i n : nat)
-  (H : (i < length (repeat x n))%nat)
+  (H : i < length (repeat x n))
   : nth' (repeat x n) i H = x.
 Proof.
   induction n as [|n IHn] in i, H |- * using nat_ind@{i}.
@@ -485,7 +484,7 @@ Defined.
 (** Two lists are equal if their [nth'] elements are equal. *)
 Definition path_list_nth'@{i|} {A : Type@{i}} (l l' : list A)
   (p : length l = length l')
-  : (forall n (H : (n < length l)%nat), nth' l n H = nth' l' n (p # H))
+  : (forall n (H : n < length l), nth' l n H = nth' l' n (p # H))
     -> l = l'.
 Proof.
   intros H.
@@ -496,7 +495,7 @@ Proof.
   destruct l' as [|a' l'].
   1: discriminate.
   f_ap.
-  - exact (H 0%nat _).
+  - exact (H 0 _).
   - snrapply IHl.
     1: by apply path_nat_succ.
     intros n Hn.
@@ -508,7 +507,7 @@ Defined.
 
 (** The [nth n] element of a concatenated list [l ++ l'] where [n < length l] is the [nth] element of [l]. *)
 Definition nth_app@{i|} {A : Type@{i}} (l l' : list A) (n : nat)
-  (H : (n < length l)%nat)
+  (H : n < length l)
   : nth (l ++ l') n = nth l n.
 Proof.
   induction l as [|a l IHl] in l', n, H |- * using list_ind@{i i}.
@@ -550,7 +549,7 @@ Defined.
 (** [drop n l] removes the first [n] elements of [l]. *)
 Fixpoint drop {A : Type} (n : nat) (l : list A) : list A :=
   match l, n with
-  | _ :: l, n.+1%nat => drop n l
+  | _ :: l, n.+1 => drop n l
   | _, _ => l
   end.
 
@@ -579,7 +578,7 @@ Defined.
 
 (** A [drop] of [n] elements with [length l <= n] is the empty list. *)
 Definition drop_length_leq@{i|} {A : Type@{i}} (n : nat) (l : list A)
-  (H : (length l <= n)%nat)
+  (H : length l <= n)
   : drop n l = nil.
 Proof.
   induction l as [|a l IHl] in H, n |- * using list_ind@{i i}.
@@ -593,7 +592,7 @@ Defined.
 
 (** The length of a [drop n] is the length of the original list minus [n]. *)
 Definition length_drop@{i|} {A : Type@{i}} (n : nat) (l : list A)
-  : length (drop n l) = (length l - n)%nat.
+  : length (drop n l) = length l - n.
 Proof.
   induction l as [|a l IHl] in n |- * using list_ind@{i i}.
   1: by rewrite drop_nil.
@@ -634,7 +633,7 @@ Defined.
 
 (** A [take] of [n] elements with [length l <= n] is the original list. *)
 Definition take_length_leq@{i|} {A : Type@{i}} (n : nat) (l : list A)
-  (H : (length l <= n)%nat)
+  (H : (length l <= n))
   : take n l = l.
 Proof.
   induction l as [|a l IHl] in H, n |- * using list_ind@{i i}.
@@ -723,7 +722,7 @@ Defined.
 
 (** Removing the [n]-th element of a list with [length l <= n] is the original list. *)
 Definition remove_length_leq {A : Type} (n : nat) (l : list A)
-  (H : (length l <= n)%nat)
+  (H : length l <= n)
   : remove n l = l.
 Proof.
   unfold remove.
@@ -736,8 +735,8 @@ Defined.
 
 (** The length of a [remove n] is the length of the original list minus one. *)
 Definition length_remove@{i|} {A : Type@{i}} (n : nat) (l : list A)
-  (H : (n < length l)%nat)
-  : length (remove n l) = nat_pred (length l)%nat.
+  (H : n < length l)
+  : length (remove n l) = nat_pred (length l).
 Proof.
   unfold remove.
   rewrite length_app@{i}.
@@ -854,10 +853,10 @@ Proof.
 Defined.
 
 (** Alternate definition of [seq_rev] that keeps the proofs of the entries being [< n]. *)
-Definition seq_rev'@{} (n : nat) : list {k : nat & (k < n)%nat}.
+Definition seq_rev'@{} (n : nat) : list {k : nat & k < n}.
 Proof.
-  transparent assert (f : (forall n, {k : nat & (k < n)%nat}
-    -> {k : nat & (k < n.+1)%nat})).
+  transparent assert (f : (forall n, {k : nat & k < n}
+    -> {k : nat & k < n.+1})).
   { intros m.
     snrapply (functor_sigma idmap).
     intros k H.
@@ -869,7 +868,7 @@ Proof.
 Defined.
 
 (** Alternate definition of [seq] that keeps the proofs of the entries being [< n]. *)
-Definition seq'@{} (n : nat) : list {k : nat & (k < n)%nat}
+Definition seq'@{} (n : nat) : list {k : nat & k < n}
   := reverse (seq_rev' n).
 
 (** The length of [seq_rev' n] is [n]. *) 
@@ -912,8 +911,8 @@ Proof.
 Defined.
 
 (** The [nth] element of a [seq_rev] is [n - i.+1]. *)
-Definition nth_seq_rev@{} {n i} (H : (i < n)%nat)
-  : nth (seq_rev n) i = Some (n - i.+1)%nat.
+Definition nth_seq_rev@{} {n i} (H : i < n)
+  : nth (seq_rev n) i = Some (n - i.+1).
 Proof.
   induction i as [|i IHi] in n, H |- *.
   - induction n.
@@ -925,13 +924,13 @@ Proof.
 Defined.
 
 (** The [nth] element of a [seq] is [i]. *)
-Definition nth_seq@{} {n i} (H : (i < n)%nat)
+Definition nth_seq@{} {n i} (H : i < n)
   : nth (seq n) i = Some i.
 Proof.
   induction n.
   1: destruct (not_lt_zero_r _ H).
   rewrite seq_succ.
-  destruct (dec (i < n)%nat) as [H'|H'].
+  destruct (dec (i < n)) as [H'|H'].
   - lhs nrapply nth_app.
     1: by rewrite length_seq.
     by apply IHn.
@@ -946,7 +945,7 @@ Proof.
 Defined.
 
 (** The [nth'] element of a [seq'] is [i]. *)
-Definition nth'_seq'@{} (n i : nat) (H : (i < length (seq' n))%nat)
+Definition nth'_seq'@{} (n i : nat) (H : i < length (seq' n))
   : (nth' (seq' n) i H).1 = i.
 Proof.
   unshelve lhs_V nrapply nth'_list_map.
@@ -960,7 +959,7 @@ Proof.
 Defined.
 
 Definition inlist_seq@{} (n : nat) x
-  : InList x (seq n) <~> (x < n)%nat.
+  : InList x (seq n) <~> (x < n).
 Proof.
   simple_induction n n IHn.
   { symmetry; apply equiv_to_empty.
@@ -1244,7 +1243,7 @@ Proof.
 Defined.
 
 Definition list_exists_seq {n : nat} (P : nat -> Type)
-  (H : forall k, P k -> (k < n)%nat)
+  (H : forall k, P k -> (k < n))
   : (exists k, P k) <-> list_exists P (seq n).
 Proof.
   split.
@@ -1261,7 +1260,7 @@ Defined.
 
 (** An upper bound on witnesses of a decidable predicate makes the sigma type decidable. *)
 Definition decidable_exists_nat (n : nat) (P : nat -> Type)
-  (H1 : forall k, P k -> (k < n)%nat)
+  (H1 : forall k, P k -> (k < n))
   (H2 : forall k, Decidable (P k))
   : Decidable (exists k, P k).
 Proof.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -959,7 +959,6 @@ Definition Build_list {A : Type} (n : nat)
   : list A
   := list_map (fun '(i; Hi) => f i Hi) (seq' n).
 
-(** The length of [Build_list] is the same as the length of the finite sequence. *)
 Definition length_Build_list {A : Type} (n : nat)
   (f : forall (i : nat), (i < n) -> A)
   : length (Build_list n f) = n.
@@ -968,7 +967,7 @@ Proof.
   apply length_seq'.
 Defined.
 
-(** Restriction an infinite sequence to a list of specified length. *)
+(** Restriction of an infinite sequence to a list of specified length. *)
 Definition list_restrict {A : Type} (s : nat -> A) (n : nat) : list A
   := Build_list n (fun m _ => s m).
 
@@ -976,27 +975,14 @@ Definition list_restrict_length {A : Type} (s : nat -> A) (n : nat)
   : length (list_restrict s n) = n
   := length_Build_list _ _.
 
-Definition list_restrict_length' {A : Type} (s t : nat -> A) (n : nat)
-  : length (list_restrict s n) = length (list_restrict t n)
-  := (list_restrict_length s n) @ (list_restrict_length t n)^.
-
 (** [nth'] of the restriction of a sequence is the corresponding term of the sequence.  *)
 Definition entry_list_restrict {A : Type} (s : nat -> A) (n : nat)
   {i : nat} (Hi : i < n)
   : nth' (list_restrict s n) i ((list_restrict_length s n)^ # Hi) = s i.
 Proof.
-  snrefine (nth'_list_map _ _ _ (_^ # Hi) _ @ _).
-  - nrapply length_seq'.
+  lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
   - exact (ap s (nth'_seq' _ _ _)).
-Defined.
-
-Definition entry_list_restrict' {A : Type} (s : nat -> A) (n : nat)
-  {i : nat} (Hi : i < length (list_restrict s n))
-  : nth' (list_restrict s n) i Hi = s i.
-Proof.
-  snrefine (nth'_list_map _ _ _ (_^ # Hi) _ @ _).
-  - nrapply ((length_seq' n) @ (list_restrict_length s n)^).
-  - exact (ap s (nth'_seq' _ _ _)).
+  Unshelve. nrapply length_seq'.
 Defined.
 
 (** ** Repeat *)

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -618,16 +618,13 @@ Defined.
 
 (** [take n l] keeps the first [n] elements of [l] and returns [l] if [n >= length l]. *)
 Fixpoint take {A : Type} (n : nat) (l : list A) : list A :=
-  match l, n with
-  | x :: l, n.+1%nat => x :: take n l
+  match n, l with
+  | n.+1, x :: l => x :: take n l
   | _, _ => nil
   end.
 
-(** A [take] of zero elements is the empty list. *)
-Definition take_0 {A : Type} (l : list A) : take 0 l = nil.
-Proof.
-  by destruct l.
-Defined.
+(** A [take] of zero elements is the empty list, by definition. *)
+Definition take_0 {A : Type} (l : list A) : take 0 l = nil := idpath.
 
 (** A [take] of the empty list is the empty list. *)
 Definition take_nil {A : Type} (n : nat) : take n (@nil A) = nil.
@@ -675,7 +672,7 @@ Proof.
   induction l as [|a l IHl] in n, H, x |- * using list_ind@{i i}.
   1: rewrite take_nil in H; contradiction.
   destruct n.
-  1: rewrite take_0 in H; contradiction.
+  { cbn in H. contradiction. }
   destruct H as [-> | H].
   - left; reflexivity.
   - right; exact (IHl _ _ H).
@@ -685,8 +682,8 @@ Defined.
 Definition take_take_min {A : Type} {m n : nat} (l : list A)
   : take n (take m l) = take (nat_min n m) l.
 Proof.
-  revert n m l; induction n, m.
-  1-3: intro l; by rewrite !take_0.
+  revert n m l; induction n, m; intro l.
+  1-3: reflexivity.
   destruct l as [|a l'].
   1: by rewrite !take_nil.
   cbn. apply ap, IHn.
@@ -704,7 +701,7 @@ Definition take_app {A : Type} {n : nat} (l1 l2 : list A) (hn : n <= length l1)
   : take n l1 = take n (l1++l2).
 Proof.
   induction n in l1, l2, hn |- *.
-  - by rewrite !take_0.
+  - reflexivity.
   - induction l1 as [|a l1 IHl1].
     + contradiction (not_lt_zero_r _ hn).
     + cbn.
@@ -721,7 +718,7 @@ Definition remove {A : Type} (n : nat) (l : list A) : list A
 Definition remove_0 {A : Type} (l : list A) : remove 0 l = tail l.
 Proof.
   unfold remove.
-  by rewrite take_0, drop_1.
+  by rewrite drop_1.
 Defined.
 
 (** Removing the [n]-th element of a list with [length l <= n] is the original list. *)

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -977,6 +977,52 @@ Proof.
   rapply equiv_iff_hprop.
 Defined.
 
+(** Turning a finite sequence into a list. This is taken from [Build_Vector]. *)
+Definition Build_list {A : Type} (n : nat)
+  (f : forall (i : nat), (i < n) -> A)
+  : list A
+  := list_map (fun '(i; Hi) => f i Hi) (seq' n).
+
+(** The length of [Build_list] is the same as the length of the finite sequence. *)
+Definition length_Build_list {A : Type} (n : nat)
+  (f : forall (i : nat), (i < n) -> A)
+  : length (Build_list n f) = n.
+Proof.
+  lhs nrapply length_list_map.
+  apply length_seq'.
+Defined.
+
+(** Restriction an infinite sequence to a list of specified length. *)
+Definition list_restrict {A : Type} (s : nat -> A) (n : nat) : list A
+  := Build_list n (fun m _ => s m).
+
+Definition list_restrict_length {A : Type} (s : nat -> A) (n : nat)
+  : length (list_restrict s n) = n
+  := length_Build_list _ _.
+
+Definition list_restrict_length' {A : Type} (s t : nat -> A) (n : nat)
+  : length (list_restrict s n) = length (list_restrict t n)
+  := (list_restrict_length s n) @ (list_restrict_length t n)^.
+
+(** [nth'] of the restriction of a sequence is the corresponding term of the sequence.  *)
+Definition entry_list_restrict {A : Type} (s : nat -> A) (n : nat)
+  {i : nat} (Hi : i < n)
+  : nth' (list_restrict s n) i ((list_restrict_length s n)^ # Hi) = s i.
+Proof.
+  snrefine (nth'_list_map _ _ _ (_^ # Hi) _ @ _).
+  - nrapply length_seq'.
+  - exact (ap s (nth'_seq' _ _ _)).
+Defined.
+
+Definition entry_list_restrict' {A : Type} (s : nat -> A) (n : nat)
+  {i : nat} (Hi : i < length (list_restrict s n))
+  : nth' (list_restrict s n) i Hi = s i.
+Proof.
+  snrefine (nth'_list_map _ _ _ (_^ # Hi) _ @ _).
+  - nrapply ((length_seq' n) @ (list_restrict_length s n)^).
+  - exact (ap s (nth'_seq' _ _ _)).
+Defined.
+
 (** ** Repeat *)
 
 (** The length of a repeated list is the number of repetitions. *)

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -969,18 +969,29 @@ Proof.
   apply length_seq'.
 Defined.
 
+Definition nth'_Build_list {A : Type} {n : nat}
+  (f : forall (i : nat), (i < n) -> A) {i : nat} (Hi : (i < n))
+  : nth' (Build_list n f) i ((length_Build_list n f)^ # Hi) = f i Hi.
+Proof.
+  unshelve lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
+  1: nrapply length_seq'.
+  snrapply ap011D.
+  1: nrapply nth'_seq'.
+  rapply path_ishprop.
+Defined.
+
 (** Restriction of an infinite sequence to a list of specified length. *)
 Definition list_restrict {A : Type} (s : nat -> A) (n : nat) : list A
   := Build_list n (fun m _ => s m).
 
-Definition list_restrict_length {A : Type} (s : nat -> A) (n : nat)
+Definition length_list_restrict {A : Type} (s : nat -> A) (n : nat)
   : length (list_restrict s n) = n
   := length_Build_list _ _.
 
 (** [nth'] of the restriction of a sequence is the corresponding term of the sequence.  *)
-Definition entry_list_restrict {A : Type} (s : nat -> A) (n : nat)
+Definition nth'_list_restrict {A : Type} (s : nat -> A) (n : nat)
   {i : nat} (Hi : i < n)
-  : nth' (list_restrict s n) i ((list_restrict_length s n)^ # Hi) = s i.
+  : nth' (list_restrict s n) i ((length_list_restrict s n)^ # Hi) = s i.
 Proof.
   unshelve lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
   - nrapply length_seq'.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -14,6 +14,8 @@ Local Set Polymorphic Inductive Cumulativity.
 (** We generally try to keep the order the same as the concepts appeared in [List.Core]. *)
 
 Local Open Scope list_scope.
+Local Open Scope nat_scope.
+Local Open Scope type_scope.
 
 (** ** Length *)
 
@@ -352,6 +354,21 @@ Proof.
   apply ap, path_ishprop.
 Defined.
 
+(** Two equal lists have the same elements in the same positions. *)
+Definition nth'_path_list {A : Type} {l1 l2 : list A}
+  (p : l1 = l2) {n : nat} (Hn : n < length l1)
+  : nth' l1 n Hn = nth' l2 n ((ap _ p) # Hn)
+  := match p with idpath => idpath end.
+
+(** Proof-independent version of [nth'_path_list]. *)
+Definition nth'_path_list' {A : Type} {l1 l2 : list A}
+  (p : l1 = l2) {n : nat} (Hn1 : n < length l1) (Hn2 : n < length l2)
+  : nth' l1 n Hn1 = nth' l2 n Hn2.
+Proof.
+  destruct p.
+  by apply nth'_nth'.
+Defined.
+
 (** The [nth'] element of a list is in the list. *)
 Definition inlist_nth'@{i|} {A : Type@{i}} (l : list A) (n : nat)
   (H : (n < length l)%nat)
@@ -645,6 +662,11 @@ Proof.
   cbn; f_ap.
 Defined.
 
+(** The length of a [take] is less than or equal to the length of the list. *)
+Definition length_take_leq {A : Type} {n : nat} (l : list A)
+  : length (take n l) <= length l
+  := transport (fun x => x <= length l) (length_take n l)^ nat_min_leq_r.
+
 (** An element of a [take] is an element of the original list. *)
 Definition take_inlist@{i|} {A : Type@{i}} (n : nat) (l : list A) (x : A)
   : InList x (take n l) -> InList x l.
@@ -657,6 +679,36 @@ Proof.
   destruct H as [-> | H].
   - left; reflexivity.
   - right; exact (IHl _ _ H).
+Defined.
+
+(** Applying a [take] twice with [m] and [n] is the same as applying it once with [nat_min m n]. *)
+Definition take_take_min {A : Type} {m n : nat} (l : list A)
+  : take n (take m l) = take (nat_min n m) l.
+Proof.
+  revert n m l; induction n, m.
+  1-3: intro l; by rewrite !take_0.
+  destruct l as [|a l'].
+  1: by rewrite !take_nil.
+  cbn. apply ap, IHn.
+Defined.
+
+(** [take] is commutative in [n]. *)
+Definition take_comm {A : Type} {m n : nat} (l : list A)
+  : take n (take m l) = take m (take n l).
+Proof.
+  by rewrite !take_take_min, nat_min_comm.
+Defined.
+
+(** A [take n] does not change under concatenation if [n] is less than or equal to the length of the first list. *)
+Definition take_app {A : Type} {n : nat} (l1 l2 : list A) (hn : n <= length l1)
+  : take n l1 = take n (l1++l2).
+Proof.
+  induction n in l1, l2, hn |- *.
+  - by rewrite !take_0.
+  - induction l1 as [|a l1 IHl1].
+    + contradiction (not_lt_zero_r _ hn).
+    + cbn.
+      apply ap, IHn, (_ hn).
 Defined.
 
 (** *** Remove *)

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -548,32 +548,22 @@ Defined.
 
 (** [drop n l] removes the first [n] elements of [l]. *)
 Fixpoint drop {A : Type} (n : nat) (l : list A) : list A :=
-  match l, n with
-  | _ :: l, n.+1 => drop n l
-  | _, _ => l
+  match n with
+  | 0 => l
+  | n.+1 => drop n (tail l)
   end.
 
-(** A [drop] of zero elements is the identity. *)
-Definition drop_0 {A : Type} (l : list A)
-  : drop 0 l = l.
-Proof.
-  by destruct l.
-Defined.
+(** A [drop] of zero elements is the identity, by definition. *)
+Definition drop_0 {A : Type} (l : list A) : drop 0 l = l := idpath.
 
-(** A [drop] of one element is the tail of the list. *)
-Definition drop_1 {A : Type} (l : list A)
-  : drop 1 l = tail l.
-Proof.
-  induction l.
-  1: reflexivity.
-  by destruct l.
-Defined.
+(** A [drop] of one element is the tail of the list, by definition. *)
+Definition drop_1 {A : Type} (l : list A) : drop 1 l = tail l := idpath.
 
 (** A [drop] of the empty list is the empty list. *)
 Definition drop_nil {A : Type} (n : nat)
   : drop n (@nil A) = nil.
 Proof.
-  by destruct n.
+  by induction n.
 Defined.
 
 (** A [drop] of [n] elements with [length l <= n] is the empty list. *)
@@ -609,7 +599,7 @@ Proof.
   induction l as [|a l IHl] in n, H, x |- * using list_ind@{i i}.
   1: rewrite drop_nil in H; contradiction.
   destruct n.
-  1: rewrite drop_0 in H; assumption.
+  1: exact H.
   right; nrapply (IHl _ _ H).
 Defined.
 
@@ -714,11 +704,7 @@ Definition remove {A : Type} (n : nat) (l : list A) : list A
   := take n l ++ drop n.+1 l.
 
 (** Removing the first element of a list is the tail of the list. *)
-Definition remove_0 {A : Type} (l : list A) : remove 0 l = tail l.
-Proof.
-  unfold remove.
-  by rewrite drop_1.
-Defined.
+Definition remove_0 {A : Type} (l : list A) : remove 0 l = tail l := idpath.
 
 (** Removing the [n]-th element of a list with [length l <= n] is the original list. *)
 Definition remove_length_leq {A : Type} (n : nat) (l : list A)

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -665,7 +665,7 @@ Defined.
 (** The length of a [take] is less than or equal to the length of the list. *)
 Definition length_take_leq {A : Type} {n : nat} (l : list A)
   : length (take n l) <= length l
-  := transport (fun x => x <= length l) (length_take n l)^ nat_min_leq_r.
+  := transport (fun x => x <= length l) (length_take n l)^ (nat_min_leq_r _ _).
 
 (** An element of a [take] is an element of the original list. *)
 Definition take_inlist@{i|} {A : Type@{i}} (n : nat) (l : list A) (x : A)

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -355,12 +355,6 @@ Defined.
 
 (** Two equal lists have the same elements in the same positions. *)
 Definition nth'_path_list {A : Type} {l1 l2 : list A}
-  (p : l1 = l2) {n : nat} (Hn : n < length l1)
-  : nth' l1 n Hn = nth' l2 n ((ap _ p) # Hn)
-  := match p with idpath => idpath end.
-
-(** Proof-independent version of [nth'_path_list]. *)
-Definition nth'_path_list' {A : Type} {l1 l2 : list A}
   (p : l1 = l2) {n : nat} (Hn1 : n < length l1) (Hn2 : n < length l2)
   : nth' l1 n Hn1 = nth' l2 n Hn2.
 Proof.

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -740,6 +740,30 @@ Proof.
   exact (ap S IH).
 Defined.
 
+(** The defining properties of [nat_max]: [m] and [n] are less than or equal to [nat_max n m] and [nat_max n m] is less than or equal to any number greater than or equal to [m] and [n]. *)
+Definition leq_nat_max_l n m : n <= nat_max m n.
+Proof.
+  induction n as [|n IHn] in m |- *; destruct m; cbn.
+  1-3: exact _.
+  exact (_ IHn m).
+Defined.
+
+Definition leq_nat_max_r n m : m <= nat_max m n.
+Proof.
+  induction n as [|n IHn] in m |- *; destruct m; cbn.
+  1-3: exact _.
+  exact (_ IHn m).
+Defined.
+
+Definition nat_max_leq {n m k : nat} (Hn : n <= k) (Hm : m <= k)
+  : nat_max n m <= k.
+Proof.
+  induction k in m, n, Hn, Hm |- *; destruct m, n; cbn.
+  1-3, 5-7: exact _.
+  - contradiction (not_lt_zero_r _ _).
+  - apply (_ IHk).
+Defined.
+
 (** [nat_max] is commutative. *)
 Definition nat_max_comm@{} n m : nat_max n m = nat_max m n.
 Proof.
@@ -801,6 +825,29 @@ Proof.
   simple_induction' n; cbn.
   1: reflexivity.
   exact (ap S IH).
+Defined.
+
+(** The defining properties of [nat_min]: [nat_min n m] is less than or equal to [m] and [n] and any number less than or equal to [m] and [n] is less than or equal to [nat_min n m]. *)
+Definition nat_min_leq_l n m : nat_min m n <= n.
+Proof.
+  induction n as [|n IHn] in m |- *; destruct m; cbn.
+  1-3: exact _.
+  exact (_ IHn m).
+Defined.
+
+Definition nat_min_leq_r n m : nat_min m n <= m.
+Proof.
+  induction n as [|n IHn] in m |- *; destruct m; cbn.
+  1-3: exact _.
+  exact (_ IHn m).
+Defined.
+
+Definition leq_nat_min {n m k : nat} (Hn : k <= n) (Hm : k <= m)
+  : k <= nat_min n m.
+Proof.
+  induction k in m, n, Hn, Hm |- *; destruct m, n; cbn.
+  1-7: exact _.
+  apply (_ IHk).
 Defined.
 
 (** [nat_min] is commutative. *)

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -743,16 +743,20 @@ Defined.
 (** The defining properties of [nat_max]: [m] and [n] are less than or equal to [nat_max n m] and [nat_max n m] is less than or equal to any number greater than or equal to [m] and [n]. *)
 Definition leq_nat_max_l@{} n m : n <= nat_max n m.
 Proof.
-  induction n as [|n IHn] in m |- *; destruct m; cbn.
-  1-3: exact _.
-  exact (_ IHn m).
+  induction n as [|n IHn] in m |- *.
+  1: exact (leq_zero_l _).
+  destruct m; cbn.
+  1: cbn; reflexivity.
+  exact (leq_succ (IHn m)).
 Defined.
 
 Definition leq_nat_max_r@{} n m : m <= nat_max n m.
 Proof.
-  induction n as [|n IHn] in m |- *; destruct m; cbn.
-  1-3: exact _.
-  exact (_ IHn m).
+  induction n as [|n IHn] in m |- *.
+  1: cbn; reflexivity.
+  destruct m; cbn.
+  1: exact (leq_zero_l _).
+  exact (leq_succ (IHn m)).
 Defined.
 
 Definition nat_max_leq@{} {n m k : nat} (Hn : n <= k) (Hm : m <= k)
@@ -761,7 +765,7 @@ Proof.
   induction k in m, n, Hn, Hm |- *; destruct m, n; cbn.
   1-3, 5-7: exact _.
   - contradiction (not_lt_zero_r _ _).
-  - apply (_ IHk).
+  - exact (leq_succ (IHk n m _ _)).
 Defined.
 
 (** [nat_max] is commutative. *)
@@ -830,16 +834,20 @@ Defined.
 (** The defining properties of [nat_min]: [nat_min n m] is less than or equal to [m] and [n] and any number less than or equal to [m] and [n] is less than or equal to [nat_min n m]. *)
 Definition nat_min_leq_l@{} n m : nat_min n m <= n.
 Proof.
-  induction n as [|n IHn] in m |- *; destruct m; cbn.
-  1-3: exact _.
-  exact (_ IHn m).
+  induction n as [|n IHn] in m |- *.
+  1: cbn; reflexivity.
+  destruct m; cbn.
+  1: exact (leq_zero_l _).
+  exact (leq_succ (IHn m)).
 Defined.
 
 Definition nat_min_leq_r@{} n m : nat_min n m <= m.
 Proof.
-  induction n as [|n IHn] in m |- *; destruct m; cbn.
-  1-3: exact _.
-  exact (_ IHn m).
+  induction n as [|n IHn] in m |- *.
+  1: exact (leq_zero_l _).
+  destruct m; cbn.
+  1: cbn; reflexivity.
+  exact (leq_succ (IHn m)).
 Defined.
 
 Definition leq_nat_min@{} {n m k : nat} (Hn : k <= n) (Hm : k <= m)
@@ -847,7 +855,7 @@ Definition leq_nat_min@{} {n m k : nat} (Hn : k <= n) (Hm : k <= m)
 Proof.
   induction k in m, n, Hn, Hm |- *; destruct m, n; cbn.
   1-7: exact _.
-  apply (_ IHk).
+  exact (leq_succ (IHk n m _ _)).
 Defined.
 
 (** [nat_min] is commutative. *)

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -741,21 +741,21 @@ Proof.
 Defined.
 
 (** The defining properties of [nat_max]: [m] and [n] are less than or equal to [nat_max n m] and [nat_max n m] is less than or equal to any number greater than or equal to [m] and [n]. *)
-Definition leq_nat_max_l n m : n <= nat_max m n.
+Definition leq_nat_max_l@{} n m : n <= nat_max n m.
 Proof.
   induction n as [|n IHn] in m |- *; destruct m; cbn.
   1-3: exact _.
   exact (_ IHn m).
 Defined.
 
-Definition leq_nat_max_r n m : m <= nat_max m n.
+Definition leq_nat_max_r@{} n m : m <= nat_max n m.
 Proof.
   induction n as [|n IHn] in m |- *; destruct m; cbn.
   1-3: exact _.
   exact (_ IHn m).
 Defined.
 
-Definition nat_max_leq {n m k : nat} (Hn : n <= k) (Hm : m <= k)
+Definition nat_max_leq@{} {n m k : nat} (Hn : n <= k) (Hm : m <= k)
   : nat_max n m <= k.
 Proof.
   induction k in m, n, Hn, Hm |- *; destruct m, n; cbn.
@@ -828,21 +828,21 @@ Proof.
 Defined.
 
 (** The defining properties of [nat_min]: [nat_min n m] is less than or equal to [m] and [n] and any number less than or equal to [m] and [n] is less than or equal to [nat_min n m]. *)
-Definition nat_min_leq_l n m : nat_min m n <= n.
+Definition nat_min_leq_l@{} n m : nat_min n m <= n.
 Proof.
   induction n as [|n IHn] in m |- *; destruct m; cbn.
   1-3: exact _.
   exact (_ IHn m).
 Defined.
 
-Definition nat_min_leq_r n m : nat_min m n <= m.
+Definition nat_min_leq_r@{} n m : nat_min n m <= m.
 Proof.
   induction n as [|n IHn] in m |- *; destruct m; cbn.
   1-3: exact _.
   exact (_ IHn m).
 Defined.
 
-Definition leq_nat_min {n m k : nat} (Hn : k <= n) (Hm : k <= m)
+Definition leq_nat_min@{} {n m k : nat} (Hn : k <= n) (Hm : k <= m)
   : k <= nat_min n m.
 Proof.
   induction k in m, n, Hn, Hm |- *; destruct m, n; cbn.


### PR DESCRIPTION
- Added properties of `nat_max` and `nat_min`.

**Lists:**
- Small addition: two equal lists have the same `nth'` terms.
- Results for `take` (two takes are the same as a take with the minimum, commutativity, invariance of `take n` with respect to concatenation if `n` is less than or equal to the length of the first list).
- A `Build_list` function for turning sequences and functions into lists, very useful for formalising bar induction. The first part is taken from the `Build_Vector` definition.